### PR TITLE
Fix Dependabot security alerts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,3 +20,4 @@ gem 'tapioca', group: :development
 gem 'thor', '>= 1.4.0'
 gem 'webmock', group: :development
 gem 'rexml', '>= 3.4.2'
+gem 'uri', '>= 1.0.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,7 +147,7 @@ GEM
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
-    uri (1.0.3)
+    uri (1.1.1)
     webmock (3.24.0)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -185,6 +185,7 @@ DEPENDENCIES
   sorbet-runtime
   tapioca
   thor (>= 1.4.0)
+  uri (>= 1.0.4)
   webmock
 
 BUNDLED WITH


### PR DESCRIPTION
## Summary
- Add uri >= 1.0.4 (fixes credential leakage bypass - CVE-2025-27221)

## Test plan
- [x] `bundle update` succeeds
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)