### PR TITLE
Support graphql 2.5.x and release 1.4.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    fragment-dev (1.4.3)
-      graphql (>= 2.2.5, < 2.5.0)
+    fragment-dev (1.4.4)
+      graphql (>= 2.2.5, < 3.0)
       graphql-client (~> 0.23.0)
       sorbet-runtime (~> 0.5)
 
@@ -25,7 +25,7 @@ GEM
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.2)
-    base64 (0.2.0)
+    base64 (0.3.0)
     benchmark (0.4.0)
     bigdecimal (3.1.9)
     coderay (1.1.3)
@@ -41,8 +41,11 @@ GEM
     ffi-compiler (1.3.2)
       ffi (>= 1.15.5)
       rake
-    graphql (2.2.17)
+    fiber-storage (1.0.1)
+    graphql (2.5.20)
       base64
+      fiber-storage
+      logger
     graphql-client (0.23.0)
       activesupport (>= 3.0)
       graphql (>= 1.13.0)
@@ -184,4 +187,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.6.2
+   2.6.7

--- a/fragment-dev.gemspec
+++ b/fragment-dev.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.summary = 'the ruby fragment client sdk'
   s.homepage = 'https://fragment.dev'
   s.license = 'Apache-2.0'
-  s.add_runtime_dependency 'graphql', '>= 2.2.5', '< 2.5.0'
+  s.add_runtime_dependency 'graphql', '>= 2.2.5', '< 3.0'
   s.add_runtime_dependency 'graphql-client', '~> 0.23.0'
   s.add_runtime_dependency 'sorbet-runtime', '~> 0.5'
 end

--- a/lib/fragment.schema.json
+++ b/lib/fragment.schema.json
@@ -16888,6 +16888,28 @@
       ],
       "directives": [
         {
+          "name": "deprecated",
+          "description": "Marks an element of a GraphQL schema as no longer supported.",
+          "locations": [
+            "FIELD_DEFINITION",
+            "ENUM_VALUE",
+            "ARGUMENT_DEFINITION",
+            "INPUT_FIELD_DEFINITION"
+          ],
+          "args": [
+            {
+              "name": "reason",
+              "description": "Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted in [Markdown](https://daringfireball.net/projects/markdown/).",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": "\"No longer supported\""
+            }
+          ]
+        },
+        {
           "name": "include",
           "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
           "locations": [
@@ -16913,6 +16935,14 @@
           ]
         },
         {
+          "name": "oneOf",
+          "description": "Requires that exactly one field must be supplied and that field must not be `null`.",
+          "locations": [
+            "INPUT_OBJECT"
+          ],
+          "args": []
+        },
+        {
           "name": "skip",
           "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
           "locations": [
@@ -16936,36 +16966,6 @@
               "defaultValue": null
             }
           ]
-        },
-        {
-          "name": "deprecated",
-          "description": "Marks an element of a GraphQL schema as no longer supported.",
-          "locations": [
-            "FIELD_DEFINITION",
-            "ENUM_VALUE",
-            "ARGUMENT_DEFINITION",
-            "INPUT_FIELD_DEFINITION"
-          ],
-          "args": [
-            {
-              "name": "reason",
-              "description": "Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted in [Markdown](https://daringfireball.net/projects/markdown/).",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": "\"No longer supported\""
-            }
-          ]
-        },
-        {
-          "name": "oneOf",
-          "description": "Requires that exactly one field must be supplied and that field must not be `null`.",
-          "locations": [
-            "INPUT_OBJECT"
-          ],
-          "args": []
         },
         {
           "name": "specifiedBy",

--- a/lib/fragment_client/version.rb
+++ b/lib/fragment_client/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FragmentSDK
-  VERSION = '1.4.3'
+  VERSION = '1.4.4'
 end


### PR DESCRIPTION
## Summary
- relax graphql runtime dependency from `< 2.5.0` to `< 3.0`
- update lockfile to resolve `graphql 2.5.20`
- bump gem version to `1.4.4`

## Notes
- Local nix-based `bundle lock --update graphql` completed successfully.
- Local nix-based `bundle install`/`rake` hit a native `ffi` compile issue in this environment; CI should validate tests and schema update on GitHub runners.

Made with [Cursor](https://cursor.com)