### PR TITLE
Bump version to 1.4.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fragment-dev (1.4.4)
+    fragment-dev (1.4.5)
       graphql (>= 2.2.5, < 3.0)
       graphql-client (~> 0.23.0)
       sorbet-runtime (~> 0.5)

--- a/lib/fragment_client/version.rb
+++ b/lib/fragment_client/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FragmentSDK
-  VERSION = '1.4.4'
+  VERSION = '1.4.5'
 end


### PR DESCRIPTION
## Summary
- bump gem version from `1.4.4` to `1.4.5`
- update lockfile path spec accordingly


Made with [Cursor](https://cursor.com)