### PR TITLE
Fix missing Content-Type header on OAuth token request

### DIFF
--- a/lib/fragment_client.rb
+++ b/lib/fragment_client.rb
@@ -166,6 +166,7 @@ class FragmentClient
     uri = URI.parse(@oauth_url.to_s)
     post = Net::HTTP::Post.new(uri.request_uri)
     post.basic_auth(@client_id, @client_secret)
+    post.content_type = "application/x-www-form-urlencoded"
     post.body = format('grant_type=client_credentials&scope=%<scope>s&client_id=%<id>s', scope: @oauth_scope,
                                                                                          id: @client_id)
 


### PR DESCRIPTION
## Problem

The `create_token` method in `FragmentClient` sends a form-encoded POST body for the OAuth client credentials grant, but does not explicitly set the `Content-Type` header to `application/x-www-form-urlencoded`.

While some OAuth servers infer the content type from the body, others — including AWS Cognito — strictly require the header to be present. Without it, these servers return **405 Method Not Allowed** because they cannot identify the request as a valid form POST.

## Fix

Added `post.content_type = "application/x-www-form-urlencoded"` to the `create_token` method, after `basic_auth` is set and before the body is assigned. This is a one-line, non-breaking change that makes the request conformant with RFC 6749 Section 4.4.2, which specifies that client credentials grant requests use `application/x-www-form-urlencoded`.

## Changes

- `lib/fragment_client.rb`: Set `Content-Type: application/x-www-form-urlencoded` on the token request.