### PR TITLE
Sync queries and the schema from upstream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,19 @@
 
 # rbenv
 .ruby-version
+
+# Local dev shell. Toolchains are a personal choice, and the gemspec and CI
+# matrix are what actually define the supported Ruby versions.
+/shell.nix
+
+# bundler, when BUNDLE_PATH points inside the worktree (sorbet/config already
+# ignores vendor/, which is why that is the useful place to put it)
+/vendor/
+/.bundle/
+
+# simplecov output
+/coverage/
+
+# Local API credentials, as `fragment <cmd> --creds` and the live tests read them.
+# Named rather than a glob, so a fixture called something.json is still committable.
+fragment.json

--- a/README.md
+++ b/README.md
@@ -184,3 +184,17 @@ fragment = FragmentClient.new(
 ```
 
 This setup allows you to enhance your SDK usage with tailored queries, ensuring you can handle all your business-specific cases effectively.
+
+## Development
+
+Requires Ruby >= 3.2, as the gemspec says; CI covers 3.2, 3.3 and 3.4.
+
+```bash
+bundle install
+bundle exec rake       # the default task
+bundle exec rake -T    # everything else
+```
+
+If your locale is not UTF-8, set one. `GraphQL::Client.load_schema` reads
+`lib/fragment.schema.json`, which carries non-ASCII currency names, and raises
+`invalid byte sequence in US-ASCII` under a US-ASCII default external encoding.

--- a/lib/fragment.schema.json
+++ b/lib/fragment.schema.json
@@ -10,6 +10,95 @@
       "subscriptionType": null,
       "types": [
         {
+          "kind": "OBJECT",
+          "name": "AddLedgerEntriesError",
+          "description": "Error returned when one or more Ledger Entries in the batch could not be added.",
+          "fields": [
+            {
+              "name": "code",
+              "description": "The status code of error. For example, 'ledger_entry_batch_operation_failed'.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "errors",
+              "description": "The list of errors for each Ledger Entry that was responsible for the batch's failure.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "AddLedgerEntryError",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "message",
+              "description": "The error message",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "retryable",
+              "description": "Whether or not the operation is retryable",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Error",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "UNION",
           "name": "AddLedgerEntriesResponse",
           "description": null,
@@ -18,6 +107,11 @@
           "interfaces": null,
           "enumValues": null,
           "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "AddLedgerEntriesError",
+              "ofType": null
+            },
             {
               "kind": "OBJECT",
               "name": "AddLedgerEntriesResult",
@@ -42,7 +136,7 @@
           "fields": [
             {
               "name": "results",
-              "description": "The committed entries, in the same order as the input entries",
+              "description": "The added Ledger Entries, in the same order as the input",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -71,6 +165,87 @@
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "AddLedgerEntryError",
+          "description": "Error details for a single Ledger Entry that was responsible for the batch's failure.",
+          "fields": [
+            {
+              "name": "code",
+              "description": "The status code of error. For example, 'ledger_entry_too_many_lines'.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ik",
+              "description": "The [Idempotency Key](https://fragment.dev/api-reference/api-overview#idempotency) of the Ledger Entry",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "SafeString",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "message",
+              "description": "The error message",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "retryable",
+              "description": "Whether or not the operation is retryable",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Error",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "INPUT_OBJECT",
           "name": "AddLedgerEntryInput",
           "description": null,
@@ -78,7 +253,7 @@
           "inputFields": [
             {
               "name": "entry",
-              "description": "The [Ledger Entry](https://fragment.dev/api-reference/api-types#input-types-ledgerentryinput) to commit",
+              "description": "The [Ledger Entry](https://fragment.dev/api-reference/api-types#input-types-ledgerentryinput) to add",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -92,7 +267,7 @@
             },
             {
               "name": "ik",
-              "description": "The [Idempotency Key](https://fragment.dev/api-reference/api-overview#idempotency) for this entry",
+              "description": "The [Idempotency Key](https://fragment.dev/api-reference/api-overview#idempotency) for this Ledger Entry",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1163,6 +1338,32 @@
           "interfaces": [],
           "enumValues": null,
           "possibleTypes": null
+        },
+        {
+          "kind": "UNION",
+          "name": "CreatePaymentResponse",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "BadRequestError",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "InternalError",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Payment",
+              "ofType": null
+            }
+          ]
         },
         {
           "kind": "OBJECT",
@@ -3222,6 +3423,16 @@
           "interfaces": [],
           "enumValues": null,
           "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "AddLedgerEntriesError",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "AddLedgerEntryError",
+              "ofType": null
+            },
             {
               "kind": "OBJECT",
               "name": "BadRequestError",
@@ -11573,11 +11784,11 @@
             },
             {
               "name": "addLedgerEntries",
-              "description": "Batch version of addLedgerEntry: commits every entry in one atomic,\nstrongly-consistent transaction. Either every entry is committed or none\nare.",
+              "description": "Batch version of [addLedgerEntry](http://localhost:3001/api-reference/ledger-mutations#addledgerentry).\n\nAdds a batch of Ledger Entries in one synchronous and atomic transaction. Either every entry is added or none are.",
               "args": [
                 {
                   "name": "entries",
-                  "description": "The entries to commit, each with its own [Idempotency Key](https://fragment.dev/api-reference/api-overview#idempotency).",
+                  "description": "The Ledger Entries to post, each with its own [Idempotency Key](https://fragment.dev/api-reference/api-overview#idempotency).",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -11892,6 +12103,65 @@
                 "ofType": {
                   "kind": "UNION",
                   "name": "CreateLedgerAccountsResponse",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createPayment",
+              "description": "EXPERIMENTAL — subject to change.\n\nCreate a Payment.",
+              "args": [
+                {
+                  "name": "amount",
+                  "description": "The amount in cents, between 100 and 10000000 inclusive.",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int96",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "ik",
+                  "description": "The [Idempotency Key](https://fragment.dev/api-reference/api-overview#idempotency)",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "SafeString",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "ledger",
+                  "description": "The Ledger this Payment belongs to.",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "LedgerMatchInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "UNION",
+                  "name": "CreatePaymentResponse",
                   "ofType": null
                 }
               },
@@ -12455,6 +12725,78 @@
           "inputFields": null,
           "interfaces": null,
           "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Payment",
+          "description": null,
+          "fields": [
+            {
+              "name": "clientSecret",
+              "description": "The secret handed to the payments SDK to render the payment method capture.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "status",
+              "description": "The status of this Payment.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "PaymentStatus",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "PaymentStatus",
+          "description": "EXPERIMENTAL — subject to change.\n\nStatus of a Payment.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "processing",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "requires_confirmation",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "settled",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null
         },
         {

--- a/lib/queries.graphql
+++ b/lib/queries.graphql
@@ -94,6 +94,52 @@ mutation DeleteLedger($ledger: LedgerMatchInput!) {
   }
 }
 
+mutation AddLedgerEntries($entries: [AddLedgerEntryInput!]!) {
+  addLedgerEntries(entries: $entries) {
+    __typename
+    ... on AddLedgerEntriesResult {
+      results {
+        isIkReplay
+        entry {
+          type
+          id
+          ik
+          posted
+          created
+        }
+        lines {
+          id
+          amount
+          account {
+            path
+          }
+        }
+      }
+    }
+    ... on AddLedgerEntriesError {
+      code
+      message
+      retryable
+      errors {
+        ik
+        code
+        message
+        retryable
+      }
+    }
+    ... on BadRequestError {
+      code
+      message
+      retryable
+    }
+    ... on InternalError {
+      code
+      message
+      retryable
+    }
+  }
+}
+
 mutation AddLedgerEntry(
   $ik: SafeString!
   $ledgerIk: SafeString!


### PR DESCRIPTION
> Written by Claude, running in Steven's session — these are Claude's words and judgements, not Steven's.

Base of the stack. Nothing here depends on the rest; it is what unblocks it.

## Why the schema has to move

`lib/queries.graphql` picks up `AddLedgerEntries`, the only operation upstream has that this repository does not.

That alone does not work. The pinned `fragment.schema.json` predates `AddLedgerEntriesError`, and graphql-client validates the whole document at parse time — so with the operation added and the schema stale, `FragmentClient.new` raised before returning:

```
No such type AddLedgerEntriesError, so it can't be a fragment condition
(GraphQL::Client::ValidationError)
```

The refresh is additive: `AddLedgerEntriesError`, `AddLedgerEntryError`, and `createPayment`/`Payment` that upstream had already added. CI regenerates this file and diffs it, so it had to come forward regardless of this stack.

## A README section on running the suite

The gemspec requires Ruby >= 3.2, macOS ships 2.6, and nothing in the repository said so. The UTF-8 note is there because a non-UTF-8 locale makes `GraphQL::Client.load_schema` fail on the non-ASCII currency names in the schema, which is a confusing way to find that out.

`.gitignore` picks up `/shell.nix` and the bundler and coverage paths, so a local toolchain stays local — per review, the gemspec and the CI matrix are what define supported versions, not a checked-in shell.

Verified: `bundle exec rake test` green (11 runs).