### PR TITLE
Fix three ways a bad oauth_url or oauth_scope failed unhelpfully

### DIFF
--- a/lib/fragment_client.rb
+++ b/lib/fragment_client.rb
@@ -81,15 +81,20 @@ class FragmentClient
 
   extend T::Sig
 
+  DEFAULT_OAUTH_URL = 'https://auth.fragment.dev/oauth2/token'
+  DEFAULT_OAUTH_SCOPE = 'https://api.fragment.dev/*'
+
   sig do
     params(client_id: String, client_secret: String, extra_queries_filenames: T.nilable(T::Array[String]),
            api_url: T.nilable(String), oauth_url: T.nilable(String), oauth_scope: T.nilable(String)).void
   end
 
   def initialize(client_id, client_secret, extra_queries_filenames: nil, api_url: nil,
-                 oauth_url: 'https://auth.fragment.dev/oauth2/token', oauth_scope: 'https://api.fragment.dev/*')
-    @oauth_scope = T.let(oauth_scope, String)
-    @oauth_url = T.let(URI.parse(oauth_url), URI)
+                 oauth_url: DEFAULT_OAUTH_URL, oauth_scope: DEFAULT_OAUTH_SCOPE)
+    # These accept nil, so nil has to mean the default rather than being asserted
+    # away -- passing `oauth_scope: nil` used to raise a TypeError from `T.let`.
+    @oauth_scope = T.let(oauth_scope || DEFAULT_OAUTH_SCOPE, String)
+    @oauth_url = T.let(parse_oauth_url(oauth_url || DEFAULT_OAUTH_URL), URI::HTTP)
     @client_id = T.let(client_id, String)
     @client_secret = T.let(client_secret, String)
 
@@ -161,12 +166,31 @@ class FragmentClient
     end
   end
 
+  # Reject an unusable `oauth_url` where it is passed.
+  #
+  # Two failures used to surface far from their cause: a non-HTTP URL reached
+  # {create_token} and died there as a NoMethodError on `request_uri`, and a
+  # malformed one raised `URI::InvalidURIError` from inside `uri`, neither
+  # mentioning the argument responsible. Both are one ArgumentError now.
+  sig { params(oauth_url: String).returns(URI::HTTP) }
+  def parse_oauth_url(oauth_url)
+    parsed = begin
+      URI.parse(oauth_url)
+    rescue URI::InvalidURIError => e
+      raise ArgumentError, "oauth_url is not a valid URL (#{e.message}), got #{oauth_url.inspect}"
+    end
+    # URI::HTTPS subclasses URI::HTTP, so this accepts both.
+    return parsed if parsed.is_a?(URI::HTTP)
+
+    raise ArgumentError, "oauth_url must be an http or https URL, got #{oauth_url.inspect}"
+  end
+
   sig { returns(Token) }
   def create_token
-    uri = URI.parse(@oauth_url.to_s)
+    uri = @oauth_url
     post = Net::HTTP::Post.new(uri.request_uri)
     post.basic_auth(@client_id, @client_secret)
-    post.content_type = "application/x-www-form-urlencoded"
+    post.content_type = 'application/x-www-form-urlencoded'
     post.body = URI.encode_www_form(
       grant_type: 'client_credentials',
       scope: @oauth_scope,

--- a/test/unit_test.rb
+++ b/test/unit_test.rb
@@ -348,6 +348,75 @@ class UnitTest < Minitest::Test
     end
   end
 
+  def test_explicit_nil_oauth_settings_fall_back_to_the_defaults
+    # Both keywords are declared nilable, so nil has to mean "use the default".
+    # Asserting it raised nothing is the point: `T.let(oauth_scope, String)` used
+    # to turn an explicit nil into a TypeError.
+    captured = nil
+    stub_request(:post, 'https://auth.fragment.dev/oauth2/token')
+      .to_return do |request|
+        captured = request
+        { status: 200, body: { access_token: 'test_token', expires_in: 3600 }.to_json }
+      end
+
+    FragmentClient.new('client_id', 'client_secret', oauth_url: nil, oauth_scope: nil)
+
+    assert_equal 'https://api.fragment.dev/*',
+                 URI.decode_www_form(captured.body).to_h['scope']
+    assert_equal 'auth.fragment.dev', captured.uri.host
+  end
+
+  def test_a_non_http_oauth_url_is_rejected_where_it_is_passed
+    # Anything without a request_uri used to get as far as create_token and fail
+    # there as a NoMethodError, which says nothing about the argument that caused
+    # it. No token request should be attempted at all.
+    stub_request(:post, /.*/).to_return(status: 200, body: '{}')
+
+    # WebMock's journal is process-global, and a test class whose teardown
+    # shadows the adapter's leaks its requests into it. Only what this test
+    # does below is relevant to the assertion at the end.
+    WebMock::RequestRegistry.instance.reset!
+
+    {
+      'ftp://auth.example.com/token' => /must be an http or https URL/,
+      'auth.fragment.dev/oauth2/token' => /must be an http or https URL/,
+      # Malformed rather than merely wrong-scheme: this used to escape as a
+      # URI::InvalidURIError that never named the argument.
+      'not a url at all' => /oauth_url is not a valid URL/
+    }.each do |bad, expected|
+      error = assert_raises(ArgumentError, "#{bad.inspect} should be rejected") do
+        FragmentClient.new('client_id', 'client_secret', oauth_url: bad)
+      end
+      assert_match expected, error.message
+      assert_match(/#{Regexp.escape(bad)}/, error.message)
+    end
+
+    assert_not_requested :post, /.*/
+  end
+
+  def test_a_plain_http_oauth_url_is_accepted
+    # The check is on the scheme family, not on TLS: a local or proxied auth
+    # endpoint over http must still work.
+    stub_request(:post, 'http://localhost:8080/oauth2/token')
+      .to_return(status: 200, body: { access_token: 't', expires_in: 3600 }.to_json)
+
+    FragmentClient.new('client_id', 'client_secret', oauth_url: 'http://localhost:8080/oauth2/token')
+
+    assert_requested :post, 'http://localhost:8080/oauth2/token'
+  end
+
+  def test_an_https_oauth_url_is_accepted
+    # URI::HTTPS subclasses URI::HTTP, so the check above must not reject it --
+    # which is the scheme every real deployment uses.
+    stub_request(:post, 'https://auth.eu-west-1.fragment.dev/oauth2/token')
+      .to_return(status: 200, body: { access_token: 't', expires_in: 3600 }.to_json)
+
+    FragmentClient.new('client_id', 'client_secret',
+                       oauth_url: 'https://auth.eu-west-1.fragment.dev/oauth2/token')
+
+    assert_requested :post, 'https://auth.eu-west-1.fragment.dev/oauth2/token'
+  end
+
   def test_token_request_uses_appendix_b_form_encoding_utf8
     captured_auth_request = nil
     stub_request(:post, 'https://auth.fragment.dev/oauth2/token')


### PR DESCRIPTION
> Written by Claude, running in Steven's session — these are Claude's words and judgements, not Steven's.

Stacked on #1. Behaviour changes, which is why they are not buried in the feature PR — they are the most likely thing here to affect an existing caller. Nothing to do with batch entries; found while putting `lib/fragment_client.rb` under Sorbet, and none of them had a test.

| | Before | After |
|---|---|---|
| `oauth_scope: nil` | `TypeError` from sorbet-runtime | uses the default |
| `oauth_url: 'ftp://…'` | `NoMethodError: request_uri`, three frames away | `ArgumentError` naming the argument |
| `oauth_url: 'not a url'` | `URI::InvalidURIError: bad URI` | `ArgumentError` naming the argument |

**The nil case is a real bug.** Both keywords are declared `T.nilable(String)`, but the body asserted `T.let(oauth_scope, String)` — so passing the nil the signature permits raised instead of falling back. Nil now means the default, which is what a nilable keyword with a non-nil default implies.

**The non-HTTP case** reached `create_token` and died on `URI::Generic#request_uri`. Rejected where it is passed now. `URI::HTTPS` subclasses `URI::HTTP`, so both schemes are accepted and plain `http` still works for a local or proxied endpoint — asserted, since that is the easy thing to get wrong when tightening this.

**The malformed case** I only found because the test for the case above used `'not a url at all'` as an example and got a different exception class out. Both are one `ArgumentError` now.

## Not included

`create_token` is still over the `AbcSize` and `MethodLength` limits. Pre-existing, and the OAuth conformance tests around it are worth not disturbing in a PR whose point is behaviour.

Verified: 15 runs, 55 assertions, green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)