### PR TITLE
Teach Sorbet about the typed payloads, via a Tapioca DSL compiler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,3 +68,11 @@ jobs:
         # exercises it, and this is what turns that into a check.
         - name: Typecheck
           run: bundle exec srb tc
+
+        # The RBI snapshot describes the surface callers touch, so regenerating it
+        # is a reviewed decision. A stale one has to fail here rather than be
+        # quietly refreshed on someone's machine.
+        - name: Verify the typed entry RBI snapshot is up-to-date
+          run: |
+            bundle exec rake snapshot
+            git diff --exit-code -- sorbet/snapshots

--- a/README.md
+++ b/README.md
@@ -142,6 +142,21 @@ FragmentClient::TypedEntries.fetch('user_funds_account', 1)
 #=> FragmentClient::Entries::UserFundsAccountV1
 ```
 
+### Sorbet
+
+The gem ships a [Tapioca](https://github.com/Shopify/tapioca) DSL compiler, so
+Sorbet can typecheck the payloads even though they are built at load time. Put a
+`TypedEntries.load` call somewhere Tapioca loads — a Rails initializer, or
+`sorbet/tapioca/require.rb` — then:
+
+```bash
+bundle exec tapioca dsl
+```
+
+That writes an RBI giving each payload a real signature. `srb tc` will then reject
+a wrong parameter type, a missing required parameter, and a parameter your Schema
+does not declare.
+
 ### Sync Transactions
 
 To sync transaction using a custom link:

--- a/Rakefile
+++ b/Rakefile
@@ -22,6 +22,15 @@ task :lint do
   sh 'bundle exec rubocop'
 end
 
+desc 'Regenerate the typed Ledger Entry payload RBI and read the diff'
+task :snapshot do
+  # The snapshot is the reviewable record of the surface a caller touches; see
+  # test/snapshot_test.rb for why regenerating it is a decision, not a chore.
+  ENV['RECORD_SNAPSHOTS'] = '1'
+  ruby '-Itest test/snapshot_test.rb'
+  sh 'git diff --stat -- sorbet/snapshots'
+end
+
 namespace :sorbet do
   desc 'Regenerate gem RBIs, annotations, and the unresolved-constant list'
   task :update do

--- a/docs/spec-conformance.md
+++ b/docs/spec-conformance.md
@@ -64,14 +64,14 @@ on every optional field.
 | 2.3 | Type and required-ness from the variable definition | `variable_types`; `NonNullType` means required | `test_requiredness_comes_from_the_variable_not_the_parameter_name` |
 | 2.3 | Payload still emitted without typed parameters | `parameters` falls back to an empty hash | `test_a_payload_is_still_derived_without_typed_parameters` |
 | 2.3a | All seven common fields exposed | `TypedLedgerEntry::COMMON_FIELDS`, fixed by `LedgerEntryInput` | `test_every_common_field_reaches_the_wire` |
-| 2.3a | `lines`, `type`, `typeVersion`, `parameters` not caller-supplied | Not declared; unknown keywords rejected | `test_lines_is_not_exposed` |
+| 2.3a | `lines`, `type`, `typeVersion`, `parameters` not caller-supplied | Not declared; unknown keywords rejected | `test_lines_is_not_exposed`; `type_check_test.rb` rejects them statically |
 | 2.4 | Parameters keep source order | `spec.parameters` is never re-sorted | `004-param-order`; and the strict-profile byte comparison, which is the assertion that actually catches a re-sort |
 | 2.5 | Name always carries the resolved version | `EntrySpec#class_name` is `<Type>V<n>` | `test_an_unpinned_version_is_normalised_to_one_in_the_name_and_on_the_wire` |
 | 2.5 | Name depends only on its own identity | Derived from `(type, version)`, nothing else | `test_a_name_does_not_depend_on_which_other_operations_are_loaded` |
 | 2.5 | Unpinned version normalised to 1 | `DEFAULT_TYPE_VERSION` at extraction, so name and wire agree | same test |
 | 2.5 | Local names unique; wire names unchanged | `local_name` claims names in source order, suffixing `_` | `003-reserved-names`; `test_colliding_local_names_stay_distinct_and_each_carries_its_own_value` |
 | 2.5 | Warn when a parameter is renamed | `logger.warn`, on `FragmentClient.configuration.logger` | `test_escaping_warns_and_never_changes_the_wire_name` |
-| 2.6 | Additive Schema changes do not break callers | Keyword arguments; identity-derived names | **snapshot pending** -- lands with the Tapioca compiler in the follow-up |
+| 2.6 | Additive Schema changes do not break callers | Keyword arguments; identity-derived names | `sorbet/snapshots/typed_entries.rbi` snapshot, `test/snapshot_test.rb` |
 | 3.1 | Batch shape and entry order | `to_entry_input`; `to_entry_inputs` maps in place | every fixture; `test_entry_order_is_preserved_and_raw_inputs_may_be_mixed_in` |
 | 3.2 | Unset omitted, never `null` | A sentinel default marks an omitted keyword; `#set?` remembers, and `entry_input` skips what was never set | `005-unset-omitted`; `test_unset_is_omitted_and_explicit_nil_is_sent`; `test_an_unset_field_is_absent_from_the_request_body` |
 | 3.3 | Wire names verbatim | `entry_parameters` keys on `wire_name` | `003-reserved-names`; `test_escaping_warns_and_never_changes_the_wire_name` |
@@ -194,6 +194,11 @@ bundle exec rake    # tests and srb tc
 | --- | --- |
 | Tests | `bundle exec rake test` |
 | Typecheck | `bundle exec rake typecheck` |
+| Regenerate the payload RBI snapshot | `bundle exec rake snapshot` |
 | Regenerate gem RBIs and annotations | `bundle exec rake sorbet:update` |
+
+The snapshot is the reviewable record of the surface callers touch. Regenerate it
+deliberately and read the diff: anything renamed or removed, and any optional
+parameter that became required, breaks existing call sites.
 
 [spec]: https://github.com/fragment-dev/graphql-queries/blob/main/shared-spec/typed-batch-entries.md

--- a/fragment-dev.gemspec
+++ b/fragment-dev.gemspec
@@ -17,7 +17,9 @@ Gem::Specification.new do |s|
     'lib/queries.graphql',
     'lib/fragment_client/version.rb',
     'lib/fragment_client/typed_entries.rb',
-    'lib/fragment_client/typed_ledger_entry.rb'
+    'lib/fragment_client/typed_ledger_entry.rb',
+    # Discovered by `tapioca dsl` via `Gem.find_files`, so the path matters.
+    'lib/tapioca/dsl/compilers/fragment_typed_entries.rb'
   ]
   s.required_ruby_version = '>= 3.2'
   s.summary = 'the ruby fragment client sdk'

--- a/lib/tapioca/dsl/compilers/fragment_typed_entries.rb
+++ b/lib/tapioca/dsl/compilers/fragment_typed_entries.rb
@@ -1,0 +1,223 @@
+# typed: strict
+# frozen_string_literal: true
+
+return unless defined?(Tapioca::Dsl::Compilers)
+
+require 'fragment_client'
+
+module Tapioca
+  module Dsl
+    module Compilers
+      # Teaches Sorbet about the typed `addLedgerEntries` payload classes that
+      # {FragmentClient::TypedEntries.load} builds at load time.
+      #
+      # The payloads are derived from a Schema's `.graphql` operations rather than
+      # generated to disk, because that is how Ruby libraries normally do this --
+      # but it also means Sorbet cannot see them. This compiler closes that gap
+      # the same way Tapioca's ActiveRecord compilers do for dynamically defined
+      # attributes: run `bundle exec tapioca dsl` and each payload gets a real
+      # `initialize` signature and typed readers.
+      #
+      #     # sorbet/rbi/dsl/fragment_client/entries/auth_capture_v1.rbi
+      #     class FragmentClient::Entries::AuthCaptureV1
+      #       sig do
+      #         params(ik: ::String, ledger_ik: ::String, user_id: ::String,
+      #                capture_amount: ::String, ...).void
+      #       end
+      #       def initialize(ik:, ledger_ik:, user_id:, capture_amount:, ...); end
+      #     end
+      #
+      # For the classes to be visible, whatever calls `TypedEntries.load` has to
+      # run when Tapioca loads the application. `load` needs no credentials and
+      # makes no network calls precisely so it can sit in an initializer.
+      class FragmentTypedEntries < Compiler
+        extend T::Sig
+
+        ConstantType = type_member { { fixed: T.class_of(FragmentClient::TypedLedgerEntry) } }
+
+        # Sorbet types for the scalars a Fragment Schema binds parameters to.
+        #
+        # Anything absent falls through to `T.untyped`: enums, input objects and
+        # scalars added to the Schema after this table was written. Guessing wrong
+        # would reject a call that the API accepts, which is worse than not
+        # checking it.
+        GRAPHQL_SCALARS = T.let(
+          {
+            'String' => '::String',
+            'ID' => '::String',
+            'SafeString' => '::String',
+            'ParameterizedString' => '::String',
+            # Serialized as ISO 8601 strings, not as Ruby date objects.
+            'Date' => '::String',
+            'DateTime' => '::String',
+            'FirstMoment' => '::String',
+            'LastMoment' => '::String',
+            'Period' => '::String',
+            'PeriodFilter' => '::String',
+            'UTCOffset' => '::String',
+            # Fragment binds its big integers to strings, which is also why the
+            # spec's strict profile can forbid float-typed parameters outright.
+            'Int96' => '::String',
+            'Int' => '::Integer',
+            'Float' => '::Float',
+            'Boolean' => 'T::Boolean',
+            'JSON' => 'T.untyped',
+            'Parameters' => 'T.untyped'
+          }.freeze,
+          T::Hash[String, String]
+        )
+
+        # The optional common fields every payload carries, and their types.
+        # Ordered as they are declared on the base class.
+        COMMON_OPTIONAL_FIELDS = T.let(
+          {
+            posted: '::String',
+            description: '::String',
+            tags: 'T::Array[T.untyped]',
+            groups: 'T::Array[T.untyped]',
+            conditions: 'T::Array[T.untyped]'
+          }.freeze,
+          T::Hash[Symbol, String]
+        )
+
+        class << self
+          extend T::Sig
+
+          sig { override.returns(T::Enumerable[Module]) }
+          def gather_constants
+            # A payload loaded into an anonymous namespace has a name Sorbet
+            # cannot resolve (`#<Module:0x...>::AuthCaptureV1`), so there is
+            # nothing to attach an RBI to. `name_of` is Tapioca's own test for
+            # that, and returns nil for exactly those.
+            descendants_of(FragmentClient::TypedLedgerEntry).select { |klass| name_of(klass) }
+          end
+        end
+
+        sig { override.void }
+        def decorate
+          spec = constant.spec
+
+          # `create_path` would declare the class with no superclass, and Sorbet
+          # would then not know a payload inherits `to_entry_input`, `set?` or the
+          # common-field readers.
+          root.create_class(constant.to_s,
+                            superclass_name: '::FragmentClient::TypedLedgerEntry') do |payload|
+            payload.create_method('initialize', parameters: initialize_parameters(spec),
+                                                return_type: 'void')
+
+            spec.parameters.each do |parameter|
+              payload.create_method(parameter.name.to_s, return_type: reader_type(parameter),
+                                                         comments: parameter_comments(parameter))
+            end
+
+            payload.create_method('entry_type', return_type: '::String', class_method: true,
+                                                comments: [comment(spec.entry_type.inspect)])
+            payload.create_method('type_version', return_type: '::Integer', class_method: true,
+                                                  comments: [comment(spec.type_version.to_s)])
+          end
+        end
+
+        private
+
+        sig do
+          params(spec: FragmentClient::TypedEntries::EntrySpec)
+            .returns(T::Array[RBI::TypedParam])
+        end
+        def initialize_parameters(spec)
+          required, optional = spec.parameters.partition(&:required)
+
+          # Required parameters before optional ones, because Sorbet rejects a
+          # `sig` that interleaves them ("Malformed `sig`. Required parameter ...
+          # must be declared before all the optional ones"), even for keyword
+          # arguments where Ruby itself permits any order.
+          #
+          # Reordering a signature is accepted as long as parameters are supplied
+          # by name, which is what spec 2.6 depends on -- and these are keyword
+          # arguments, so declaration order is invisible to a caller. Source order
+          # is preserved within each group, and on the wire, which is where spec
+          # 2.4 is observable.
+          parameters = [
+            create_kw_param('ik', type: '::String'),
+            create_kw_param('ledger_ik', type: '::String')
+          ]
+          required.each do |parameter|
+            parameters << create_kw_param(parameter.name.to_s, type: sorbet_type(parameter))
+          end
+          optional.each do |parameter|
+            parameters << create_kw_opt_param(parameter.name.to_s, type: optional_type(parameter),
+                                                                   default: 'T.unsafe(nil)')
+          end
+          COMMON_OPTIONAL_FIELDS.each do |name, type|
+            parameters << create_kw_opt_param(name.to_s, type: nilable(type),
+                                                         default: 'T.unsafe(nil)')
+          end
+
+          parameters
+        end
+
+        sig { params(parameter: FragmentClient::TypedEntries::Parameter).returns(String) }
+        def reader_type(parameter)
+          parameter.required ? sorbet_type(parameter) : optional_type(parameter)
+        end
+
+        sig { params(parameter: FragmentClient::TypedEntries::Parameter).returns(String) }
+        def optional_type(parameter)
+          nilable(sorbet_type(parameter))
+        end
+
+        # An optional field is nilable and nothing more exotic. The unset sentinel
+        # never reaches a caller -- it is the constructor's private marker for an
+        # omitted keyword -- so putting it in the signature would only make every
+        # optional field harder to read and to narrow.
+        sig { params(type: String).returns(String) }
+        def nilable(type)
+          type == 'T.untyped' ? 'T.untyped' : "T.nilable(#{type})"
+        end
+
+        # Translate the GraphQL type of the bound variable, as written in the
+        # operation, into a Sorbet type.
+        #
+        # Top-level nullability is the caller's business, since it also has to
+        # fold in the unset sentinel. Nullability *inside* a list is folded in
+        # here, because nothing else can express it.
+        sig { params(parameter: FragmentClient::TypedEntries::Parameter).returns(String) }
+        def sorbet_type(parameter)
+          graphql_type_to_sorbet(parameter.graphql_type)
+        end
+
+        sig { params(graphql_type: String).returns(String) }
+        def graphql_type_to_sorbet(graphql_type)
+          type = graphql_type.delete_suffix('!')
+          return GRAPHQL_SCALARS.fetch(type, 'T.untyped') unless type.start_with?('[')
+
+          "T::Array[#{list_element_type(type.delete_prefix('[').delete_suffix(']'))}]"
+        end
+
+        sig { params(element: String).returns(String) }
+        def list_element_type(element)
+          type = graphql_type_to_sorbet(element)
+          return type if element.end_with?('!') || type == 'T.untyped'
+
+          "T.nilable(#{type})"
+        end
+
+        sig { params(parameter: FragmentClient::TypedEntries::Parameter).returns(T::Array[RBI::Comment]) }
+        def parameter_comments(parameter)
+          text = "Schema parameter `#{parameter.wire_name}` (`#{parameter.graphql_type}`)."
+          # Worth naming: the caller is using an identifier they did not choose,
+          # and it is not the one the API sees.
+          if parameter.escaped?
+            text += " Exposed as `#{parameter.name}` because `#{parameter.wire_name}` is " \
+                    'already taken; the wire name is unchanged.'
+          end
+          [comment(text)]
+        end
+
+        sig { params(text: String).returns(RBI::Comment) }
+        def comment(text)
+          RBI::Comment.new(text)
+        end
+      end
+    end
+  end
+end

--- a/sorbet/snapshots/typed_entries.rbi
+++ b/sorbet/snapshots/typed_entries.rbi
@@ -1,0 +1,142 @@
+# DO NOT EDIT MANUALLY
+# Snapshot of the RBI that `bundle exec tapioca dsl` generates for the typed
+# Ledger Entry payloads `FragmentClient::TypedEntries.load` builds at load
+# time. Regenerate with `bundle exec rake snapshot`.
+#
+# In this repository the payloads come from test/fixtures/snapshot_entries.graphql,
+# a synthetic Schema shaped to exercise every branch of the derivation. The
+# entry types below are not real Fragment entry types -- they exist so that
+# `test/snapshot_test.rb` has a reviewable diff and `srb tc` has something to
+# check. In your own application the equivalent file lands in
+# `sorbet/rbi/dsl/`, generated from your Schema's operations.
+
+# typed: true
+
+class FragmentClient::Entries::AuthCaptureV1 < ::FragmentClient::TypedLedgerEntry
+  sig { params(ik: ::String, ledger_ik: ::String, user_id: ::String, capture_amount: ::String, posted: T.nilable(::String), description: T.nilable(::String), tags: T.nilable(T::Array[T.untyped]), groups: T.nilable(T::Array[T.untyped]), conditions: T.nilable(T::Array[T.untyped])).void }
+  def initialize(ik:, ledger_ik:, user_id:, capture_amount:, posted: T.unsafe(nil), description: T.unsafe(nil), tags: T.unsafe(nil), groups: T.unsafe(nil), conditions: T.unsafe(nil)); end
+
+  # Schema parameter `user_id` (`String!`).
+  sig { returns(::String) }
+  def user_id; end
+
+  # Schema parameter `capture_amount` (`Int96!`).
+  sig { returns(::String) }
+  def capture_amount; end
+
+  # "auth_capture"
+  sig { returns(::String) }
+  def self.entry_type; end
+
+  # 1
+  sig { returns(::Integer) }
+  def self.type_version; end
+end
+
+class FragmentClient::Entries::Entry2faChallengeV1 < ::FragmentClient::TypedLedgerEntry
+  sig { params(ik: ::String, ledger_ik: ::String, posted: T.nilable(::String), description: T.nilable(::String), tags: T.nilable(T::Array[T.untyped]), groups: T.nilable(T::Array[T.untyped]), conditions: T.nilable(T::Array[T.untyped])).void }
+  def initialize(ik:, ledger_ik:, posted: T.unsafe(nil), description: T.unsafe(nil), tags: T.unsafe(nil), groups: T.unsafe(nil), conditions: T.unsafe(nil)); end
+
+  # "2fa_challenge"
+  sig { returns(::String) }
+  def self.entry_type; end
+
+  # 1
+  sig { returns(::Integer) }
+  def self.type_version; end
+end
+
+class FragmentClient::Entries::ReservedV1 < ::FragmentClient::TypedLedgerEntry
+  sig { params(ik: ::String, ledger_ik: ::String, type: ::String, class_: ::String, posted_: ::String, userId: ::String, posted: T.nilable(::String), description: T.nilable(::String), tags: T.nilable(T::Array[T.untyped]), groups: T.nilable(T::Array[T.untyped]), conditions: T.nilable(T::Array[T.untyped])).void }
+  def initialize(ik:, ledger_ik:, type:, class_:, posted_:, userId:, posted: T.unsafe(nil), description: T.unsafe(nil), tags: T.unsafe(nil), groups: T.unsafe(nil), conditions: T.unsafe(nil)); end
+
+  # Schema parameter `type` (`String!`).
+  sig { returns(::String) }
+  def type; end
+
+  # Schema parameter `class` (`String!`). Exposed as `class_` because `class` is already taken; the wire name is unchanged.
+  sig { returns(::String) }
+  def class_; end
+
+  # Schema parameter `posted` (`String!`). Exposed as `posted_` because `posted` is already taken; the wire name is unchanged.
+  sig { returns(::String) }
+  def posted_; end
+
+  # Schema parameter `userId` (`String!`).
+  sig { returns(::String) }
+  def userId; end
+
+  # "reserved"
+  sig { returns(::String) }
+  def self.entry_type; end
+
+  # 1
+  sig { returns(::Integer) }
+  def self.type_version; end
+end
+
+class FragmentClient::Entries::UserFundsAccountV1 < ::FragmentClient::TypedLedgerEntry
+  sig { params(ik: ::String, ledger_ik: ::String, amount: ::String, posted: T.nilable(::String), description: T.nilable(::String), tags: T.nilable(T::Array[T.untyped]), groups: T.nilable(T::Array[T.untyped]), conditions: T.nilable(T::Array[T.untyped])).void }
+  def initialize(ik:, ledger_ik:, amount:, posted: T.unsafe(nil), description: T.unsafe(nil), tags: T.unsafe(nil), groups: T.unsafe(nil), conditions: T.unsafe(nil)); end
+
+  # Schema parameter `amount` (`Int96!`).
+  sig { returns(::String) }
+  def amount; end
+
+  # "user-funds-account"
+  sig { returns(::String) }
+  def self.entry_type; end
+
+  # 1
+  sig { returns(::Integer) }
+  def self.type_version; end
+end
+
+class FragmentClient::Entries::UserFundsAccountV2 < ::FragmentClient::TypedLedgerEntry
+  sig { params(ik: ::String, ledger_ik: ::String, amount: ::String, isExternal: T::Boolean, tagKeys: T::Array[::String], mode: T.untyped, feeAmount: T.nilable(::String), settledAt: T.nilable(::String), retryCount: T.nilable(::Integer), noteLines: T.nilable(T::Array[T.nilable(::String)]), channel: T.untyped, posted: T.nilable(::String), description: T.nilable(::String), tags: T.nilable(T::Array[T.untyped]), groups: T.nilable(T::Array[T.untyped]), conditions: T.nilable(T::Array[T.untyped])).void }
+  def initialize(ik:, ledger_ik:, amount:, isExternal:, tagKeys:, mode:, feeAmount: T.unsafe(nil), settledAt: T.unsafe(nil), retryCount: T.unsafe(nil), noteLines: T.unsafe(nil), channel: T.unsafe(nil), posted: T.unsafe(nil), description: T.unsafe(nil), tags: T.unsafe(nil), groups: T.unsafe(nil), conditions: T.unsafe(nil)); end
+
+  # Schema parameter `amount` (`Int96!`).
+  sig { returns(::String) }
+  def amount; end
+
+  # Schema parameter `feeAmount` (`Int96`).
+  sig { returns(T.nilable(::String)) }
+  def feeAmount; end
+
+  # Schema parameter `settledAt` (`DateTime`).
+  sig { returns(T.nilable(::String)) }
+  def settledAt; end
+
+  # Schema parameter `isExternal` (`Boolean!`).
+  sig { returns(T::Boolean) }
+  def isExternal; end
+
+  # Schema parameter `retryCount` (`Int`).
+  sig { returns(T.nilable(::Integer)) }
+  def retryCount; end
+
+  # Schema parameter `tagKeys` (`[SafeString!]!`).
+  sig { returns(T::Array[::String]) }
+  def tagKeys; end
+
+  # Schema parameter `noteLines` (`[String]`).
+  sig { returns(T.nilable(T::Array[T.nilable(::String)])) }
+  def noteLines; end
+
+  # Schema parameter `mode` (`TransferMode!`).
+  sig { returns(T.untyped) }
+  def mode; end
+
+  # Schema parameter `channel` (`TransferChannel`).
+  sig { returns(T.untyped) }
+  def channel; end
+
+  # "user-funds-account"
+  sig { returns(::String) }
+  def self.entry_type; end
+
+  # 2
+  sig { returns(::Integer) }
+  def self.type_version; end
+end

--- a/sorbet/type_checks/typed_entries.rb
+++ b/sorbet/type_checks/typed_entries.rb
@@ -1,0 +1,95 @@
+# typed: strict
+# frozen_string_literal: true
+
+# Static assertions about the typed Ledger Entry payloads. Never loaded at
+# runtime; `srb tc` is the whole point of the file.
+#
+# The payload classes are built at load time, so nothing about their signatures is
+# visible to Sorbet without the RBI in `sorbet/snapshots/typed_entries.rbi`. This
+# is what proves that RBI is more than a file on disk: if the Tapioca compiler
+# emitted a signature Sorbet rejects, or the wrong type for a parameter, this
+# fails to typecheck.
+#
+# The payloads here come from `test/fixtures/snapshot_entries.graphql` and are
+# synthetic. `test/type_check_test.rb` covers the other direction -- that wrong
+# calls are actually *rejected* -- because Sorbet has no way to assert an expected
+# error inline.
+module FragmentTypeChecks
+  extend T::Sig
+
+  # Required parameters are required, and typed from the operation's variables.
+  sig { returns(FragmentClient::Entries::AuthCaptureV1) }
+  def self.minimal
+    FragmentClient::Entries::AuthCaptureV1.new(
+      ik: 'ik-1', ledger_ik: 'prod', user_id: 'user-1', capture_amount: '100'
+    )
+  end
+
+  # Every optional common field is accepted, and so is an explicit nil. The two
+  # stay distinguishable on the wire (spec 3.2) without the caller ever seeing a
+  # sentinel: `#set?` is what reports the difference.
+  sig { returns(FragmentClient::Entries::AuthCaptureV1) }
+  def self.with_common_fields
+    FragmentClient::Entries::AuthCaptureV1.new(
+      ik: 'ik-1', ledger_ik: 'prod', user_id: 'user-1', capture_amount: '100',
+      posted: '2026-01-01T00:00:00Z', description: nil,
+      tags: [{ key: 'k', value: 'v' }], groups: [], conditions: []
+    )
+  end
+
+  # Non-String scalars keep their Ruby types: `Int` is an Integer, `Boolean` a
+  # boolean, `[SafeString!]!` an array of strings, and an unmapped enum lands on
+  # `T.untyped` rather than being guessed at.
+  sig { returns(FragmentClient::Entries::UserFundsAccountV2) }
+  def self.scalar_types
+    FragmentClient::Entries::UserFundsAccountV2.new(
+      ik: 'ik-2', ledger_ik: 'prod', amount: '100', isExternal: true,
+      tagKeys: %w[a b], mode: :transfer, retryCount: 3, noteLines: ['first', nil]
+    )
+  end
+
+  # A parameter whose Schema name is unusable as a method name is reachable under
+  # its escaped name (spec 2.5).
+  sig { returns(String) }
+  def self.escaped_names
+    entry = FragmentClient::Entries::ReservedV1.new(
+      ik: 'r-1', ledger_ik: 'prod', type: 't', class_: 'c', posted_: 'p', userId: 'u'
+    )
+    entry.class_ + entry.posted_ + entry.type + entry.userId
+  end
+
+  # A required parameter's reader is not nilable, so it needs no narrowing.
+  sig { returns(Integer) }
+  def self.required_reader_needs_no_narrowing
+    minimal.user_id.length
+  end
+
+  # An optional one's does, and the sentinel is part of what has to be narrowed.
+  sig { returns(T.nilable(Integer)) }
+  def self.optional_reader_must_be_narrowed
+    fee = scalar_types.feeAmount
+    fee.is_a?(String) ? fee.length : nil
+  end
+
+  # The derived facts are readable off the class.
+  sig { returns([String, Integer]) }
+  def self.identity
+    [FragmentClient::Entries::UserFundsAccountV2.entry_type,
+     FragmentClient::Entries::UserFundsAccountV2.type_version]
+  end
+
+  # A batch takes typed payloads and raw hashes together (spec 3.5).
+  sig { params(client: FragmentClient).returns(T.untyped) }
+  def self.batch(client)
+    client.add_ledger_entries(
+      entries: [minimal, { ik: 'raw', entry: { ledger: { ik: 'prod' }, type: 'other' } }]
+    )
+  end
+
+  # `to_entry_input` is a plain hash, so a caller can inspect or adjust a payload
+  # before sending it.
+  sig { returns(T::Hash[String, T.untyped]) }
+  def self.wire_payload
+    minimal.to_entry_input
+  end
+end

--- a/test/fixtures/snapshot_entries.graphql
+++ b/test/fixtures/snapshot_entries.graphql
@@ -1,0 +1,113 @@
+# Input for the RBI snapshot test. Not a real Schema's operations -- it is shaped
+# to exercise every branch of the derivation in one document, so that any change
+# to a generated identifier or signature shows up as a reviewable diff.
+#
+# Covers: an unpinned version, two versions of one entry type, a parameter fixed
+# by the operation, optional and required parameters, list and non-String
+# scalars, an unknown scalar both required and optional, a camelCase parameter,
+# names that collide with a method the payload inherits, and an entry type needing
+# a constant-name prefix.
+
+mutation PostAuthCapture(
+  $ik: SafeString!
+  $ledgerIk: SafeString!
+  $posted: DateTime
+  $user_id: String!
+  $capture_amount: Int96!
+) {
+  addLedgerEntry(
+    ik: $ik
+    entry: {
+      ledger: { ik: $ledgerIk }
+      type: "auth_capture"
+      posted: $posted
+      parameters: { user_id: $user_id, capture_amount: $capture_amount }
+    }
+  ) {
+    __typename
+  }
+}
+
+mutation PostUserFundsAccount(
+  $ik: SafeString!
+  $ledgerIk: SafeString!
+  $amount: Int96!
+) {
+  addLedgerEntry(
+    ik: $ik
+    entry: {
+      ledger: { ik: $ledgerIk }
+      type: "user-funds-account"
+      typeVersion: 1
+      parameters: { amount: $amount }
+    }
+  ) {
+    __typename
+  }
+}
+
+mutation PostUserFundsAccountV2(
+  $ik: SafeString!
+  $ledgerIk: SafeString!
+  $amount: Int96!
+  $feeAmount: Int96
+  $settledAt: DateTime
+  $isExternal: Boolean!
+  $retryCount: Int
+  $tagKeys: [SafeString!]!
+  $noteLines: [String]
+  $mode: TransferMode!
+  $channel: TransferChannel
+) {
+  addLedgerEntry(
+    ik: $ik
+    entry: {
+      ledger: { ik: $ledgerIk }
+      type: "user-funds-account"
+      typeVersion: 2
+      parameters: {
+        amount: $amount
+        feeAmount: $feeAmount
+        settledAt: $settledAt
+        isExternal: $isExternal
+        retryCount: $retryCount
+        tagKeys: $tagKeys
+        noteLines: $noteLines
+        mode: $mode
+        channel: $channel
+        source: "always_api"
+      }
+    }
+  ) {
+    __typename
+  }
+}
+
+mutation PostReserved(
+  $ik: SafeString!
+  $ledgerIk: SafeString!
+  $type: String!
+  $class: String!
+  $posted_p: String!
+  $userId: String!
+) {
+  addLedgerEntry(
+    ik: $ik
+    entry: {
+      ledger: { ik: $ledgerIk }
+      type: "reserved"
+      parameters: { type: $type, class: $class, posted: $posted_p, userId: $userId }
+    }
+  ) {
+    __typename
+  }
+}
+
+mutation Post2faChallenge($ik: SafeString!, $ledgerIk: SafeString!) {
+  addLedgerEntry(
+    ik: $ik
+    entry: { ledger: { ik: $ledgerIk }, type: "2fa_challenge" }
+  ) {
+    __typename
+  }
+}

--- a/test/gem_test.rb
+++ b/test/gem_test.rb
@@ -22,4 +22,11 @@ class GemTest < Minitest::Test
     assert_equal on_disk, (spec.files & on_disk).sort,
                  "not listed in fragment-dev.gemspec: #{(on_disk - spec.files).inspect}"
   end
+
+  def test_the_tapioca_compiler_is_where_tapioca_looks_for_it
+    # `tapioca dsl` finds compilers shipped by gems with
+    # `Gem.find_files("tapioca/dsl/compilers/*.rb")`, which resolves against the
+    # load path. Anywhere else in `lib/` and it is never loaded.
+    assert_path_exists File.join(ROOT, 'lib/tapioca/dsl/compilers/fragment_typed_entries.rb')
+  end
 end

--- a/test/snapshot_test.rb
+++ b/test/snapshot_test.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+# typed: true
+
+require 'logger'
+require 'minitest/autorun'
+require 'tapioca/internal'
+require 'tapioca/dsl/compilers/fragment_typed_entries'
+require 'fragment_client'
+
+# Snapshot of the RBI the Tapioca DSL compiler generates.
+#
+# Spec 2.6 requires code generation to be backward-compatible across additive and
+# order-only Schema changes: adding an entry type or a new version of one,
+# reordering parameters, and adding an optional parameter must none of them break
+# caller source. That guarantee is about generated identifiers and signatures, so
+# it is not expressible in the shared language-neutral fixtures -- each SDK has to
+# carry its own snapshot instead, so any change surfaces as a reviewable diff
+# rather than silently.
+#
+# In Ruby the payload classes are built at load time, not generated to disk, so
+# the artifact worth snapshotting is the RBI: it is the only durable, reviewable
+# description of the surface a caller (and Sorbet) sees.
+#
+# The snapshot lives under `sorbet/` rather than beside this test so that `srb tc`
+# checks it too, and so `sorbet/type_checks/typed_entries.rb` can call into it. A
+# snapshot nothing typechecks could assert a signature Sorbet rejects and still
+# pass. Not under `sorbet/rbi/dsl/`, though: that directory belongs to Tapioca,
+# which deletes anything there it did not just generate.
+#
+# Regenerate with `bundle exec rake snapshot` and read the diff.
+class SnapshotTest < Minitest::Test
+  FIXTURE = File.expand_path('fixtures/snapshot_entries.graphql', __dir__)
+  SNAPSHOT = File.expand_path('../sorbet/snapshots/typed_entries.rbi', __dir__)
+
+  HEADER = <<~RBI
+    # DO NOT EDIT MANUALLY
+    # Snapshot of the RBI that `bundle exec tapioca dsl` generates for the typed
+    # Ledger Entry payloads `FragmentClient::TypedEntries.load` builds at load
+    # time. Regenerate with `bundle exec rake snapshot`.
+    #
+    # In this repository the payloads come from test/fixtures/snapshot_entries.graphql,
+    # a synthetic Schema shaped to exercise every branch of the derivation. The
+    # entry types below are not real Fragment entry types -- they exist so that
+    # `test/snapshot_test.rb` has a reviewable diff and `srb tc` has something to
+    # check. In your own application the equivalent file lands in
+    # `sorbet/rbi/dsl/`, generated from your Schema's operations.
+
+  RBI
+
+  def setup
+    FragmentClient.configure { |config| config.logger = Logger.new(File::NULL) }
+    FragmentClient::TypedEntries.reset!
+  end
+
+  def teardown
+    FragmentClient::TypedEntries.reset!
+    FragmentClient.instance_variable_set(:@configuration, nil)
+  end
+
+  def test_generated_rbi_matches_the_snapshot
+    actual = self.class.generate
+
+    if ENV['RECORD_SNAPSHOTS']
+      FileUtils.mkdir_p(File.dirname(SNAPSHOT))
+      File.write(SNAPSHOT, actual)
+      skip 'recorded snapshot'
+    end
+
+    assert_equal File.read(SNAPSHOT), actual, <<~MESSAGE
+      The generated RBI no longer matches sorbet/snapshots/typed_entries.rbi.
+
+      Every difference here is a change to the surface a caller touches. Renaming
+      or removing anything, or turning an optional parameter into a required one,
+      breaks existing call sites for what may be a purely additive Schema change
+      (spec 2.6).
+
+      If the change is intended, regenerate with `bundle exec rake snapshot`.
+    MESSAGE
+  end
+
+  # What the fixture has to keep reaching for the snapshot to be worth having.
+  BRANCHES = {
+    'an escaped parameter name' => :escaped?.to_proc,
+    'an optional parameter' => ->(p) { !p.required },
+    'a list-typed parameter' => ->(p) { p.graphql_type.start_with?('[') },
+    'a nullable list element' => ->(p) { p.graphql_type == '[String]' },
+    'a non-String scalar' => ->(p) { p.graphql_type.start_with?('Int96') },
+    'an Integer-typed parameter' => ->(p) { p.graphql_type == 'Int' },
+    'a Boolean-typed parameter' => ->(p) { p.graphql_type == 'Boolean!' },
+    'a required type with no Sorbet mapping' => ->(p) { p.graphql_type == 'TransferMode!' },
+    # An unmapped type that is also optional: the unset sentinel must not be
+    # folded into `T.untyped`, which already includes nil.
+    'an optional type with no Sorbet mapping' => ->(p) { p.graphql_type == 'TransferChannel' }
+  }.freeze
+
+  def test_the_fixture_exercises_every_branch_worth_snapshotting
+    # A snapshot only guards what it covers. If the fixture stops reaching one of
+    # these, the snapshot silently stops protecting it.
+    FragmentClient::TypedEntries.load(FIXTURE, namespace: Module.new)
+    registry = FragmentClient::TypedEntries.registry
+    parameters = registry.values.flat_map(&:parameters)
+
+    BRANCHES.each do |description, predicate|
+      assert parameters.any? { |parameter| predicate.call(parameter) },
+             "the fixture no longer covers #{description}"
+    end
+
+    assert_equal 5, registry.length, 'entry type coverage changed'
+    assert_equal [1, 2],
+                 registry.keys.select { |type, _| type == 'user-funds-account' }.map(&:last),
+                 'the fixture no longer covers one entry type at two versions'
+  end
+
+  # Runs the real compiler through Tapioca's pipeline, so the snapshot is the RBI
+  # `bundle exec tapioca dsl` would write and not a second renderer that could
+  # drift from it.
+  def self.generate
+    FragmentClient::TypedEntries.reset!
+    # Into the real namespace: a class reached only through an anonymous module is
+    # named `#<Module:0x...>::AuthCaptureV1`, which Sorbet cannot resolve and the
+    # compiler therefore skips.
+    payloads = FragmentClient::TypedEntries.load(FIXTURE)
+
+    pipeline = Tapioca::Dsl::Pipeline.new(
+      requested_constants: payloads,
+      requested_compilers: [Tapioca::Dsl::Compilers::FragmentTypedEntries],
+      # In this process rather than forked workers. Tapioca parallelises with
+      # `Parallel.map(in_processes:)`, and work done in a fork is invisible to
+      # both SimpleCov and any failure this test would otherwise report directly.
+      number_of_workers: 1
+    )
+
+    # One file rather than Tapioca's file-per-constant, because a single snapshot
+    # is what makes the diff readable.
+    bodies = pipeline.run { |constant, rbi| [constant.name, rbi.string] }
+                     .sort_by(&:first)
+                     .map { |_name, body| body.sub(/\A# typed: true\n\n/, '') }
+
+    "#{HEADER}# typed: true\n\n#{bodies.join("\n")}"
+  end
+end

--- a/test/type_check_test.rb
+++ b/test/type_check_test.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+# typed: true
+
+require 'minitest/autorun'
+require 'open3'
+require 'tmpdir'
+
+# That wrong calls to a typed payload are actually *rejected*.
+#
+# `sorbet/type_checks/typed_entries.rb` covers the positive direction and is
+# checked by the repository's own `srb tc`. This covers the negative one, which
+# Sorbet cannot express inline: there is no way to mark a line as
+# expected-to-fail, so the only way to assert an error is to run `srb tc` over a
+# file and read what comes back.
+#
+# Without this, the RBI could loosen every parameter to `T.untyped` and both the
+# snapshot and the positive checks would still pass -- while callers silently lost
+# the type errors the whole feature exists to give them.
+class TypeCheckTest < Minitest::Test
+  ROOT = File.expand_path('..', __dir__)
+
+  # Each case is a snippet plus the substring `srb tc` must report for it.
+  CASES = {
+    'a wrong parameter type' => [
+      "FragmentClient::Entries::AuthCaptureV1.new(ik: 'i', ledger_ik: 'l', " \
+      "user_id: 123, capture_amount: '1')",
+      'Expected `String` but found `Integer(123)` for argument `user_id`'
+    ],
+    'a missing required parameter' => [
+      "FragmentClient::Entries::AuthCaptureV1.new(ik: 'i', ledger_ik: 'l', user_id: 'u')",
+      'Missing required keyword argument `capture_amount`'
+    ],
+    'a parameter the entry type does not declare' => [
+      "FragmentClient::Entries::AuthCaptureV1.new(ik: 'i', ledger_ik: 'l', user_id: 'u', " \
+      "capture_amount: '1', nope: 'x')",
+      'Unrecognized keyword argument `nope`'
+    ],
+    # `lines` cannot be combined with an entry that has a `type` (spec 2.3a).
+    'lines' => [
+      "FragmentClient::Entries::AuthCaptureV1.new(ik: 'i', ledger_ik: 'l', user_id: 'u', " \
+      "capture_amount: '1', lines: [])",
+      'Unrecognized keyword argument `lines`'
+    ],
+    # The wire name, not the name the payload exposes it under (spec 2.5).
+    'a parameter under its unescaped Schema name' => [
+      "FragmentClient::Entries::ReservedV1.new(ik: 'i', ledger_ik: 'l', type: 't', " \
+      "class: 'c', posted_: 'p', userId: 'u')",
+      'Unrecognized keyword argument `class`'
+    ],
+    # An optional parameter's reader is nilable, so it still has to be narrowed --
+    # just as a plain nilable value, with no sentinel to learn about.
+    'an optional parameter read without narrowing' => [
+      "FragmentClient::Entries::UserFundsAccountV2.new(ik: 'i', ledger_ik: 'l', amount: '1', " \
+      'isExternal: true, tagKeys: [], mode: :m).feeAmount.length',
+      'Method `length` does not exist on `NilClass` component of `T.nilable(String)`'
+    ],
+    'a batch method given something other than an array' => [
+      "FragmentClient.new('id', 'secret').add_ledger_entries(entries: 'not an array')",
+      'for argument `entries`'
+    ]
+  }.freeze
+
+  def test_each_wrong_call_is_rejected
+    CASES.each do |description, (snippet, expected)|
+      errors = typecheck(snippet)
+
+      assert_includes errors, expected,
+                      "#{description} was not rejected as expected.\nsrb tc said:\n#{errors}"
+    end
+  end
+
+  def test_the_positive_checks_are_not_vacuous
+    # `sorbet/type_checks/typed_entries.rb` only means something if the same
+    # harness reports nothing for a correct call.
+    assert_empty typecheck(
+      "FragmentClient::Entries::AuthCaptureV1.new(ik: 'i', ledger_ik: 'l', " \
+      "user_id: 'u', capture_amount: '1')"
+    )
+  end
+
+  private
+
+  # Run `srb tc` over the repository plus one extra file holding `snippet`.
+  #
+  # The file lives outside the repository, so a failed run cannot leave a stray
+  # source file behind; Sorbet still loads the whole project from `sorbet/config`,
+  # which is what makes the payload RBI visible.
+  def typecheck(snippet)
+    Dir.mktmpdir('fragment-type-check') do |dir|
+      path = File.join(dir, 'negative.rb')
+      File.write(path, "# typed: true\n# frozen_string_literal: true\n\n#{snippet}\n")
+
+      out, status = Open3.capture2e('bundle', 'exec', 'srb', 'tc', path, chdir: ROOT)
+      return '' if status.success?
+
+      # Only the extra file's errors; the repository itself is expected to be
+      # clean, and `test_the_positive_checks_are_not_vacuous` is what proves it.
+      out.lines.grep(/negative\.rb:/).join
+    end
+  end
+end


### PR DESCRIPTION
> Written by Claude, running in Steven's session — these are Claude's words and judgements, not Steven's.

Stacked on #57. The payloads there are built at load time, so Sorbet cannot see them and a caller gets no checking on the very parameters the feature exists to type. This closes that the way Rails does for dynamically defined attributes.

The gem ships `lib/tapioca/dsl/compilers/fragment_typed_entries.rb`, which Tapioca finds via `Gem.find_files` — so the path matters, and there is a test asserting it. A consumer runs `bundle exec tapioca dsl` and gets:

```ruby
class FragmentClient::Entries::AuthCaptureV1 < ::FragmentClient::TypedLedgerEntry
  sig { params(ik: ::String, ledger_ik: ::String, user_id: ::String, capture_amount: ::String, …).void }
  def initialize(ik:, ledger_ik:, user_id:, capture_amount:, …); end
```

Types come from the bound variable, never from the parameter name. Anything outside the table lands on `T.untyped`: rejecting a call the API accepts is worse than not checking it.

**Required parameters come first in the signature.** Sorbet refuses a `sig` that interleaves required and optional keyword arguments, even though Ruby permits any order. Per your call, reordering is fine because callers supply them by name — which is what §2.6 actually depends on. Source order is preserved within each group and on the wire, where §2.4 is observable.

## Three verifications, checking different things

**`sorbet/snapshots/typed_entries.rbi`** is the §2.6 snapshot the spec requires each SDK to carry. It lives under `sorbet/` rather than beside the test so `srb tc` checks it too — a snapshot nothing typechecks could assert a signature Sorbet rejects and still pass. *Not* under `sorbet/rbi/dsl/`: Tapioca owns that directory and prunes it, and did delete the file when I tried.

**`sorbet/type_checks/typed_entries.rb`** is the positive half, checked by the repo's own `srb tc`.

**`test/type_check_test.rb`** is the negative half, which Sorbet cannot express inline — it shells out to `srb tc` over deliberately wrong calls and asserts each is rejected:

| Wrong call | Rejected with |
|---|---|
| `user_id: 123` | Expected `String` but found `Integer(123)` |
| missing `capture_amount` | Missing required keyword argument |
| `nope: 'x'` | Unrecognized keyword argument |
| `lines: []` | Unrecognized keyword argument |
| `class: 'c'` (pre-escape name) | Unrecognized keyword argument |
| `.feeAmount.length` | does not exist on `NilClass` |

Without it the RBI could loosen every parameter to `T.untyped` and both the snapshot and the positive file would still pass, while callers silently lost the errors. Loosening one parameter in the snapshot fails two tests — checked.

`test/snapshot_test.rb` also asserts the fixture still reaches every branch worth snapshotting, since a snapshot only guards what it covers. It runs the compiler through Tapioca's real pipeline with `number_of_workers: 1`, so the snapshot is what `tapioca dsl` would write rather than a second renderer that could drift.

Verified: 75 runs, 330 assertions, `srb tc` clean, snapshot regenerates identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)