### PR TITLE
Measure coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,9 +43,9 @@ jobs:
               exit 1
             fi
 
-  # Checks that only need running once: Sorbet reads the same files whatever Ruby
-  # is running, the checked-in gem RBIs were generated against one resolution of
-  # the lockfile, and a coverage threshold is not per-version.
+  # Checks that only need running once. Sorbet reads the same files whatever Ruby
+  # is running, and the checked-in gem RBIs correspond to one resolution of the
+  # lockfile.
   quality:
     name: Quality
     runs-on: ubuntu-latest

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'rubocop-graphql', group: :development
 gem 'rubocop-minitest', group: :development
 gem 'rubocop-performance', group: :development
 gem 'rubocop-rake', group: :development
+gem 'simplecov', group: :development
 gem 'sorbet', group: :development
 gem 'sorbet-runtime'
 gem 'tapioca', group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,7 @@ GEM
       rubocop (~> 1.0)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
+    simplecov (1.0.3)
     sorbet (0.5.11798)
       sorbet-static (= 0.5.11798)
     sorbet-runtime (0.5.11798)
@@ -179,6 +180,7 @@ DEPENDENCIES
   rubocop-minitest
   rubocop-performance
   rubocop-rake
+  simplecov
   sorbet
   sorbet-runtime
   tapioca

--- a/Rakefile
+++ b/Rakefile
@@ -17,6 +17,13 @@ task :typecheck do
   sh 'bundle exec srb tc'
 end
 
+desc 'Run the tests under SimpleCov; report in coverage/index.html'
+task :coverage do
+  # Read by test/test_helper.rb. Rake::TestTask shells out, so it is inherited.
+  ENV['COVERAGE'] = '1'
+  Rake::Task['test'].invoke
+end
+
 desc 'Lint with RuboCop'
 task :lint do
   sh 'bundle exec rubocop'

--- a/test/add_ledger_entries_test.rb
+++ b/test/add_ledger_entries_test.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 # typed: true
 
+require 'test_helper'
 require 'json'
 require 'logger'
 require 'minitest/autorun'
 require 'tempfile'
 require 'webmock/minitest'
-require 'fragment_client'
 
 # `FragmentClient#add_ledger_entries` end to end, through the real
 # `graphql-client` transport.

--- a/test/compatibiliy_test.rb
+++ b/test/compatibiliy_test.rb
@@ -1,23 +1,24 @@
 # frozen_string_literal: true
 # typed: true
 
+require 'test_helper'
 require 'graphql/client'
 require 'minitest/autorun'
 require 'webmock/minitest'
 
 class CompatibilityTest < Minitest::Test
-def test_warning_about_duplicate_all_rules_constant
-  # Capture stderr to check warning messages
-  original_stderr = $stderr
-  $stderr = StringIO.new
-  
-  # Load fragment_client which should trigger the warning
-  require 'fragment_client'
-  
-  warning_output = $stderr.string
-  $stderr = original_stderr
+  def test_warning_about_duplicate_all_rules_constant
+    # Capture stderr to check warning messages
+    original_stderr = $stderr
+    $stderr = StringIO.new
 
-  # Verify both warning messages appear
+    # Load fragment_client which should trigger the warning
+    require 'fragment_client'
+
+    warning_output = $stderr.string
+    $stderr = original_stderr
+
+    # Verify both warning messages appear
     assert_empty warning_output, "Expected no warnings but got: #{warning_output}"
   end
 end

--- a/test/conformance_test.rb
+++ b/test/conformance_test.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 # typed: true
 
+require 'test_helper'
 require 'json'
 require 'logger'
 require 'minitest/autorun'
-require 'fragment_client'
 
 # Runner over the shared conformance fixtures in `test/spec/conformance`.
 #

--- a/test/gem_test.rb
+++ b/test/gem_test.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 # typed: true
 
+require 'test_helper'
 require 'minitest/autorun'
-require 'fragment_client'
 
 class GemTest < Minitest::Test
   ROOT = File.expand_path('..', __dir__)

--- a/test/snapshot_test.rb
+++ b/test/snapshot_test.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 # typed: true
 
+require 'test_helper'
 require 'logger'
 require 'minitest/autorun'
 require 'tapioca/internal'
 require 'tapioca/dsl/compilers/fragment_typed_entries'
-require 'fragment_client'
 
 # Snapshot of the RBI the Tapioca DSL compiler generates.
 #

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+# typed: false
+
+# Required first by every test file, so coverage measurement starts before
+# anything under `lib/` loads -- SimpleCov cannot see an already-required file.
+#
+# Opt in with `bundle exec rake coverage`.
+if ENV['COVERAGE']
+  require 'simplecov'
+
+  SimpleCov.start do
+    enable_coverage :branch
+    command_name 'minitest'
+    cover 'lib/**/*.rb'
+    skip %r{^/test/}
+    skip %r{^/vendor/}
+  end
+end
+
+require 'fragment_client'

--- a/test/typed_entries_test.rb
+++ b/test/typed_entries_test.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 # typed: true
 
+require 'test_helper'
 require 'json'
 require 'logger'
 require 'minitest/autorun'
 require 'stringio'
-require 'fragment_client'
 
 # Derivation and serialization rules of the shared `typed-batch-entries.md`
 # specification that its language-neutral fixtures cannot express.

--- a/test/unit_test.rb
+++ b/test/unit_test.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 # typed: true
 
+require 'test_helper'
 require 'minitest/autorun'
 require 'webmock/minitest'
 require 'base64'
-require 'fragment_client'
 
 class UnitTest < Minitest::Test
   include WebMock::API


### PR DESCRIPTION
> Written by Claude, running in Steven's session — these are Claude's words and judgements, not Steven's.

Stacked on #58. There was no coverage tooling; running it once found that several things in this stack had no tests — most pointedly the `oauth_url` validation shipped as #55.

**Coverage does something mutation testing cannot.** Breaking a line and watching a test fail proves the test is worth having. It says nothing about code no test executes. I had only been doing the first.

| | Before | After |
|---|---|---|
| Line | 91.2% | 99.3% |
| Branch | 75.7% | 95.5% |

The tests that closed those gaps live in the PRs whose code they cover, not here. Beyond the OAuth cases it found:

- **Two §2.1 recognition conditions** the derivation documents in its own docstring and nothing exercised: a fragment spread at the root, and no `entry` argument at all.
- A document holding a `fragment` definition alongside its operations.
- The compiler's optional-unmapped-type path, needing a fixture parameter both unmapped *and* optional.

It also revealed that Tapioca forks its workers, so the compiler read as 0%-covered while being fully exercised — fixed with `number_of_workers: 1` in #58, which makes that test deterministic too.

## Tooling, not a gate

Per review, no minimum is set and CI does not run it. It is here for whoever needs to ask the question next: `bundle exec rake coverage` writes `coverage/index.html`.

Opt-in via `COVERAGE` so `rake test` stays fast. `test_helper.rb` has to be required first by each test file — SimpleCov cannot see an already-loaded file — which is why every test file changes here, and is the bulk of the diff.

Four lines and five branches remain uncovered. Two of the lines are **dead code predating this work**: `FragmentClient#logger` is private and called by nothing, and `FragmentGraphQl::CustomClient::Definition#definition_name` belongs to a class graphql-client never instantiates. Both want removing, but removing a constant is semver-visible and deserves its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)