### PR TITLE
Bump version to 2.1.0 and write the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,60 @@
 # Changelog
 
+## [2.1.0]
+
+### Added
+
+- `add_ledger_entries` commits a batch of Ledger Entries atomically. It accepts
+  raw `AddLedgerEntryInput` hashes, typed payloads, or both in one batch, and
+  preserves their order.
+- Typed batch payloads. `FragmentClient::TypedEntries.load` derives one payload
+  class per `(Ledger Entry type, typeVersion)` from the per-entry-type
+  `addLedgerEntry` operations the Fragment CLI generates for your Schema, so a
+  batch can be built with real parameter names instead of untyped hashes:
+
+  ```ruby
+  fragment.add_ledger_entries(entries: [
+    FragmentClient::Entries::UserFundsAccountV1.new(
+      ik: 'some-ik', ledger_ik: 'your-ledger-ik', user_id: 'user-1', funding_amount: '200'
+    )
+  ])
+  ```
+
+  Payloads are registered automatically from `extra_queries_filenames`. A field
+  you did not set is omitted from the request rather than sent as `null`.
+- Sorbet support, via three Tapioca DSL compilers. Run `bundle exec tapioca dsl`
+  after loading your operations and Sorbet checks both the typed payloads and every
+  query method -- `client.create_ledger(...)` previously reported `Method
+  'create_ledger' does not exist`, because those methods are defined per instance.
+  Response fields are typed too, from each operation's selection set and the
+  Schema, so `client.get_ledger(...).data&.ledger&.name` is checked and reading a
+  field the operation did not select is a type error rather than a runtime one.
+  See the README's Sorbet section.
+- `FragmentClient.load_queries`, which registers a `.graphql` document's operations
+  and typed payloads without credentials, for use in an initializer.
+- `bundle exec rake coverage`, writing `coverage/index.html`.
+- `docs/spec-conformance.md`, mapping this SDK onto the shared
+  `typed-batch-entries` specification section by section, with its deviations.
+
+### Changed
+
+- `lib/fragment.schema.json` refreshed. Adds `AddLedgerEntriesError` and
+  `AddLedgerEntryError`, without which `addLedgerEntries` could not be parsed at
+  all, plus `createPayment` and `Payment` from upstream.
+- `oauth_url` and `oauth_scope` now treat an explicit `nil` as "use the default",
+  where before it raised a `TypeError` from the type assertion in the constructor.
+- An unusable `oauth_url` now raises `ArgumentError` from `FragmentClient.new`,
+  naming the argument and its value. **This changes the exception class in two
+  cases.** A non-HTTP URL previously failed later, inside the token request, as
+  `NoMethodError: undefined method 'request_uri'`; a malformed one escaped as
+  `URI::InvalidURIError`. Both were constructor-time failures on a misconfigured
+  URL rather than handled paths, which is why this is a minor rather than a major
+  release — but if you rescue `URI::InvalidURIError` around client construction,
+  rescue `ArgumentError` instead.
+- `lib/fragment_client.rb` typechecks under Sorbet (`# typed: true`), and `srb tc`
+  runs in CI. The checked-in gem RBIs were several major versions stale and have
+  been regenerated.
+
 ## [2.0.0]
 
 ### Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fragment-dev (2.0.0)
+    fragment-dev (2.1.0)
       graphql (>= 2.2.5, < 3.0)
       graphql-client (~> 0.23.0)
       sorbet-runtime (~> 0.5)

--- a/lib/fragment_client/version.rb
+++ b/lib/fragment_client/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FragmentSDK
-  VERSION = '2.0.0'
+  VERSION = '2.1.0'
 end


### PR DESCRIPTION
> Written by Claude, running in Steven's session — these are Claude's words and judgements, not Steven's.

Top of the stack, on #63. Release artifacts only — version, changelog, and the `fragment-dev` line in `Gemfile.lock` that follows from it.

Split out because this repository releases that way (`Bump version to 1.4.5`, `Update 2.0.0 Changelog`), and a version bump has no business inside a PR about anything else.

## Why minor

Everything user-facing in the stack is additive: the batch method, the typed payloads, the two Tapioca compilers, `load_queries`, `rake coverage`. Nothing removed, no signature narrowed. The hand-written `add_ledger_entries` wrapper cannot shadow an existing caller's method because the operation was not in `queries.graphql` before #54.

## The argument against, which the changelog states

#55 changes the exception class raised for an unusable `oauth_url`:

| Input | Before | After |
|---|---|---|
| `'ftp://…'` | `NoMethodError: undefined method 'request_uri'`, raised later inside the token request | `ArgumentError` from `FragmentClient.new` |
| `'not a url'` | `URI::InvalidURIError: bad URI` | `ArgumentError` from `FragmentClient.new` |

Strictly that is breaking. I think minor is right — both were constructor-time crashes on misconfiguration rather than paths anyone handles, and nobody rescues `NoMethodError`. But it is a judgement call, so the changelog says so and tells anyone rescuing `URI::InvalidURIError` to rescue `ArgumentError`. My first draft documented only the first row and silently omitted the second, which is the one someone might plausibly have caught.

If you would rather ship 3.0.0 on that basis, it is a one-line change here.

## No dependency versions moved

Worth saying because #56 is a 58k-line diff that looks like a dependency bump. The gemspec's constraints and `required_ruby_version` are untouched, and no locked gem changed — the lockfile already had tapioca 0.16.8, graphql 2.6.7 and activesupport 8.1.3, and only the checked-in RBIs were behind. The one addition anywhere is `simplecov` as a development dependency, in #59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)