### PR TITLE
Separate the generic GraphQL and Sorbet helpers

### DIFF
--- a/fragment-dev.gemspec
+++ b/fragment-dev.gemspec
@@ -18,6 +18,9 @@ Gem::Specification.new do |s|
     'lib/fragment_client/version.rb',
     'lib/fragment_client/typed_entries.rb',
     'lib/fragment_client/typed_ledger_entry.rb',
+    'lib/fragment_client/graphql_ast.rb',
+    # Generic; separated so it can become its own gem later.
+    'lib/tapioca/dsl/helpers/graphql_sorbet_types.rb',
     # Discovered by `tapioca dsl` via `Gem.find_files`, so the path matters.
     'lib/tapioca/dsl/compilers/fragment_typed_entries.rb'
   ]

--- a/lib/fragment_client/graphql_ast.rb
+++ b/lib/fragment_client/graphql_ast.rb
@@ -1,0 +1,73 @@
+# typed: strict
+# frozen_string_literal: true
+
+require 'graphql'
+require 'sorbet-runtime'
+
+class FragmentClient
+  # Reading helpers for graphql-ruby's language AST.
+  #
+  # Nothing here knows about Fragment. Kept separate so it can move to a gem of
+  # its own if a second consumer appears -- no such gem exists today.
+  #
+  # Named `GraphqlAst` rather than `GraphQL::Ast`: a `FragmentClient::GraphQL`
+  # would shadow the real `GraphQL` for every constant lookup inside
+  # {FragmentClient}.
+  module GraphqlAst
+    extend T::Sig
+
+    class << self
+      extend T::Sig
+
+      # The operation's only root field, if it is a field with that name.
+      #
+      # `nil` for the wrong operation type, more than one selection, or a
+      # selection that is a fragment spread rather than a field.
+      sig do
+        params(operation: GraphQL::Language::Nodes::OperationDefinition,
+               field_name: String, operation_type: String)
+          .returns(T.nilable(GraphQL::Language::Nodes::Field))
+      end
+      def single_root_field(operation, field_name, operation_type: 'mutation')
+        return nil unless operation.operation_type == operation_type
+
+        selections = operation.selections
+        return nil unless selections.length == 1
+
+        root = selections.first
+        return nil unless root.is_a?(GraphQL::Language::Nodes::Field)
+
+        root.name == field_name ? root : nil
+      end
+
+      # An argument's value when it is written as an inline object literal, as
+      # opposed to passed as a variable or absent.
+      sig do
+        params(field: GraphQL::Language::Nodes::Field, argument_name: String)
+          .returns(T.nilable(GraphQL::Language::Nodes::InputObject))
+      end
+      def inline_object_argument(field, argument_name)
+        value = field.arguments.find { |argument| argument.name == argument_name }&.value
+        value.is_a?(GraphQL::Language::Nodes::InputObject) ? value : nil
+      end
+
+      # One field of an inline object literal, or `nil` if absent. A field written
+      # as `null` yields a `NullValue` node, not `nil`.
+      sig do
+        params(object: GraphQL::Language::Nodes::InputObject, name: String).returns(T.untyped)
+      end
+      def object_field(object, name)
+        object.arguments.find { |argument| argument.name == name }&.value
+      end
+
+      # Variable name to declared type node.
+      sig do
+        params(operation: GraphQL::Language::Nodes::OperationDefinition)
+          .returns(T::Hash[String, T.untyped])
+      end
+      def variable_types(operation)
+        operation.variables.to_h { |definition| [definition.name, definition.type] }
+      end
+    end
+  end
+end

--- a/lib/fragment_client/typed_entries.rb
+++ b/lib/fragment_client/typed_entries.rb
@@ -5,6 +5,7 @@ require 'graphql'
 require 'logger'
 require 'sorbet-runtime'
 
+require 'fragment_client/graphql_ast'
 require 'fragment_client/typed_ledger_entry'
 
 class FragmentClient
@@ -253,51 +254,28 @@ class FragmentClient
 
         # A literal `type` is what makes an operation entry-type-specific; a
         # variable one leaves nothing to key a payload on.
-        entry_type = object_field(entry, 'type')
+        entry_type = GraphqlAst.object_field(entry, 'type')
         return nil unless entry_type.is_a?(String)
 
-        version = object_field(entry, 'typeVersion')
+        version = GraphqlAst.object_field(entry, 'typeVersion')
 
         EntrySpec.new(
           entry_type: entry_type,
           type_version: version.is_a?(Integer) ? version : DEFAULT_TYPE_VERSION,
           operation_name: name,
-          parameters: extract_parameters(object_field(entry, 'parameters'), operation)
+          parameters: extract_parameters(GraphqlAst.object_field(entry, 'parameters'), operation)
         )
       end
 
       # The inline `entry:` object of a single-field `addLedgerEntry` mutation, or
-      # `nil` for a query, a multi-field selection, a root fragment spread, or an
-      # `entry` passed as a variable.
+      # `nil` for anything that fails a condition of spec 2.1.
       sig do
         params(operation: GraphQL::Language::Nodes::OperationDefinition)
           .returns(T.nilable(GraphQL::Language::Nodes::InputObject))
       end
-      # One guard per numbered condition in spec 2.1.
-      # rubocop:disable Metrics/CyclomaticComplexity
       def entry_argument(operation)
-        return nil unless operation.operation_type == 'mutation'
-
-        selections = operation.selections
-        return nil unless selections.length == 1
-
-        root = selections.first
-        return nil unless root.is_a?(GraphQL::Language::Nodes::Field)
-        return nil unless root.name == ADD_LEDGER_ENTRY_FIELD
-
-        argument = root.arguments.find { |a| a.name == 'entry' }
-        value = argument&.value
-        value.is_a?(GraphQL::Language::Nodes::InputObject) ? value : nil
-      end
-      # rubocop:enable Metrics/CyclomaticComplexity
-
-      # One field of an inline object literal, or `nil` if absent. A field written
-      # as `null` yields a `NullValue` node, not `nil`.
-      sig do
-        params(object: GraphQL::Language::Nodes::InputObject, name: String).returns(T.untyped)
-      end
-      def object_field(object, name)
-        object.arguments.find { |argument| argument.name == name }&.value
+        root = GraphqlAst.single_root_field(operation, ADD_LEDGER_ENTRY_FIELD)
+        root && GraphqlAst.inline_object_argument(root, 'entry')
       end
 
       # The typed parameters bound to the entry's `parameters` object (spec 2.3).
@@ -309,7 +287,7 @@ class FragmentClient
       def extract_parameters(node, operation)
         return [] unless node.is_a?(GraphQL::Language::Nodes::InputObject)
 
-        types = variable_types(operation)
+        types = GraphqlAst.variable_types(operation)
         taken = T.let({}, T::Hash[Symbol, String])
 
         node.arguments.filter_map do |argument|
@@ -333,15 +311,6 @@ class FragmentClient
             required: type.is_a?(GraphQL::Language::Nodes::NonNullType)
           )
         end
-      end
-
-      # Variable name to declared type node.
-      sig do
-        params(operation: GraphQL::Language::Nodes::OperationDefinition)
-          .returns(T::Hash[String, T.untyped])
-      end
-      def variable_types(operation)
-        operation.variables.to_h { |definition| [definition.name, definition.type] }
       end
 
       # --- Naming (spec 2.5) -------------------------------------------------

--- a/lib/tapioca/dsl/compilers/fragment_typed_entries.rb
+++ b/lib/tapioca/dsl/compilers/fragment_typed_entries.rb
@@ -4,6 +4,7 @@
 return unless defined?(Tapioca::Dsl::Compilers)
 
 require 'fragment_client'
+require 'tapioca/dsl/helpers/graphql_sorbet_types'
 
 module Tapioca
   module Dsl
@@ -143,27 +144,9 @@ module Tapioca
           type == 'T.untyped' ? 'T.untyped' : "T.nilable(#{type})"
         end
 
-        # The bound variable's GraphQL type as a Sorbet type. Top-level nullability
-        # is the caller's to apply; nullability inside a list is applied here.
         sig { params(parameter: FragmentClient::TypedEntries::Parameter).returns(String) }
         def sorbet_type(parameter)
-          graphql_type_to_sorbet(parameter.graphql_type)
-        end
-
-        sig { params(graphql_type: String).returns(String) }
-        def graphql_type_to_sorbet(graphql_type)
-          type = graphql_type.delete_suffix('!')
-          return GRAPHQL_SCALARS.fetch(type, 'T.untyped') unless type.start_with?('[')
-
-          "T::Array[#{list_element_type(type.delete_prefix('[').delete_suffix(']'))}]"
-        end
-
-        sig { params(element: String).returns(String) }
-        def list_element_type(element)
-          type = graphql_type_to_sorbet(element)
-          return type if element.end_with?('!') || type == 'T.untyped'
-
-          "T.nilable(#{type})"
+          Helpers::GraphqlSorbetTypes.translate(parameter.graphql_type, scalars: GRAPHQL_SCALARS)
         end
 
         sig { params(parameter: FragmentClient::TypedEntries::Parameter).returns(T::Array[RBI::Comment]) }

--- a/lib/tapioca/dsl/helpers/graphql_sorbet_types.rb
+++ b/lib/tapioca/dsl/helpers/graphql_sorbet_types.rb
@@ -1,0 +1,53 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Tapioca
+  module Dsl
+    module Helpers
+      # Translates a GraphQL type expression, as written in a document, into a
+      # Sorbet type string.
+      #
+      # Nothing here knows about Fragment: the scalar table is supplied by the
+      # caller, and anything absent from it becomes `T.untyped`. Kept separate so
+      # it can move to a gem of its own if a second consumer appears -- no gem
+      # does this today, and Tapioca ships no GraphQL compiler.
+      #
+      #     translate('[SafeString!]!', scalars: { 'SafeString' => '::String' })
+      #     #=> "T::Array[::String]"
+      #     translate('[String]', scalars: { 'String' => '::String' })
+      #     #=> "T::Array[T.nilable(::String)]"
+      #
+      # Top-level nullability is the caller's to apply, since only the caller knows
+      # whether an optional field is nilable, defaulted, or something else.
+      # Nullability inside a list is applied here, having nowhere else to go.
+      module GraphqlSorbetTypes
+        extend T::Sig
+
+        UNTYPED = 'T.untyped'
+
+        class << self
+          extend T::Sig
+
+          sig { params(graphql_type: String, scalars: T::Hash[String, String]).returns(String) }
+          def translate(graphql_type, scalars:)
+            type = graphql_type.delete_suffix('!')
+            return scalars.fetch(type, UNTYPED) unless type.start_with?('[')
+
+            element = type.delete_prefix('[').delete_suffix(']')
+            "T::Array[#{list_element(element, scalars: scalars)}]"
+          end
+
+          private
+
+          sig { params(element: String, scalars: T::Hash[String, String]).returns(String) }
+          def list_element(element, scalars:)
+            type = translate(element, scalars: scalars)
+            return type if element.end_with?('!') || type == UNTYPED
+
+            "T.nilable(#{type})"
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/graphql_sorbet_types_test.rb
+++ b/test/graphql_sorbet_types_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+# typed: true
+
+require 'test_helper'
+require 'minitest/autorun'
+require 'tapioca/internal'
+require 'tapioca/dsl/helpers/graphql_sorbet_types'
+
+# Direct tests for the generic type translation, which knows nothing about
+# Fragment and is separated so it can be lifted into its own gem.
+class GraphqlSorbetTypesTest < Minitest::Test
+  SCALARS = { 'String' => '::String', 'Int' => '::Integer', 'Boolean' => 'T::Boolean',
+              'JSON' => 'T.untyped' }.freeze
+
+  CASES = {
+    'String' => '::String',
+    'String!' => '::String',
+    'Int!' => '::Integer',
+    'Boolean' => 'T::Boolean',
+    # Absent from the table: an enum, an input object, a scalar added later.
+    'TransferMode!' => 'T.untyped',
+    'JSON' => 'T.untyped',
+    # Non-null elements stay non-nilable; nullable ones do not.
+    '[String!]!' => 'T::Array[::String]',
+    '[String!]' => 'T::Array[::String]',
+    '[String]' => 'T::Array[T.nilable(::String)]',
+    '[String]!' => 'T::Array[T.nilable(::String)]',
+    '[Int]' => 'T::Array[T.nilable(::Integer)]',
+    # An unmapped element is already `T.untyped`, which includes nil.
+    '[TransferMode]' => 'T::Array[T.untyped]',
+    '[[String!]!]!' => 'T::Array[T::Array[::String]]'
+  }.freeze
+
+  def test_translates_every_shape
+    CASES.each do |graphql, sorbet|
+      assert_equal sorbet,
+                   Tapioca::Dsl::Helpers::GraphqlSorbetTypes.translate(graphql, scalars: SCALARS),
+                   "#{graphql} translated wrongly"
+    end
+  end
+
+  def test_the_scalar_table_is_the_callers
+    assert_equal 'MyString',
+                 Tapioca::Dsl::Helpers::GraphqlSorbetTypes.translate(
+                   'String!', scalars: { 'String' => 'MyString' }
+                 )
+    assert_equal 'T.untyped',
+                 Tapioca::Dsl::Helpers::GraphqlSorbetTypes.translate('String!', scalars: {})
+  end
+end


### PR DESCRIPTION
> Written by Claude, running in Steven's session — these are Claude's words and judgements, not Steven's.

Stacked on the comment pass. Behaviour-preserving — the RBI snapshot is byte-identical.

Two pieces of the derivation know nothing about Fragment, and would be the whole of a small gem if a second consumer appeared. Moved into their own files so lifting them out later is a `git mv`.

## No such gem exists to depend on instead

I checked rather than assumed. Tapioca ships no GraphQL compiler. [`sorbet-typed`](https://github.com/sorbet/sorbet-typed) carries hand-written definitions, not generation. The nearest thing is [`theorygeek/yogurt`](https://github.com/theorygeek/yogurt), which takes a different approach — its own client and its own codegen rather than Tapioca — and is 3 stars, 44 commits, self-described as "a fairly early stage of development", with no releases and an acknowledged gap on named fragments. Not something to build on.

## What moved

**`Tapioca::Dsl::Helpers::GraphqlSorbetTypes`** translates a GraphQL type expression into a Sorbet type — nullability, lists, nested lists. The scalar table is the caller's, and anything missing becomes `T.untyped`, so nothing Fragment-specific leaks in. `lib/tapioca/dsl/helpers/` is Tapioca's own convention for helpers shared between compilers. It gets direct tests, because coverage through the payload compiler would not survive extraction.

**`FragmentClient::GraphqlAst`** reads graphql-ruby's language AST: an operation's single root field, an argument written as an inline object literal, one field of such an object, an operation's variable types.

Named `GraphqlAst` and not `GraphQL::Ast` deliberately — a `FragmentClient::GraphQL` would shadow the real `GraphQL` for every constant lookup inside `FragmentClient`.

## What stayed

The part that is actually about Fragment: which operations qualify (§2.1), identity on `(type, typeVersion)`, payload naming and escaping (§2.5), and the wire payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)