### PR TITLE
Type the query methods, so Sorbet can see the whole client

### DIFF
--- a/fragment-dev.gemspec
+++ b/fragment-dev.gemspec
@@ -21,8 +21,9 @@ Gem::Specification.new do |s|
     'lib/fragment_client/graphql_ast.rb',
     # Generic; separated so it can become its own gem later.
     'lib/tapioca/dsl/helpers/graphql_sorbet_types.rb',
-    # Discovered by `tapioca dsl` via `Gem.find_files`, so the path matters.
-    'lib/tapioca/dsl/compilers/fragment_typed_entries.rb'
+    # Discovered by `tapioca dsl` via `Gem.find_files`, so the paths matter.
+    'lib/tapioca/dsl/compilers/fragment_typed_entries.rb',
+    'lib/tapioca/dsl/compilers/fragment_query_methods.rb'
   ]
   s.required_ruby_version = '>= 3.2'
   s.summary = 'the ruby fragment client sdk'

--- a/lib/fragment_client.rb
+++ b/lib/fragment_client.rb
@@ -84,6 +84,40 @@ module FragmentGraphQl
     FragmentQueries.const_get(name)
   end
 
+  # The instance method `FragmentClient` defines for an operation:
+  # `ListLedgerAccounts` -> `list_ledger_accounts`.
+  sig { params(operation_name: String).returns(String) }
+  def self.method_name_for(operation_name)
+    operation_name.gsub(/[a-z]([A-Z])/) do |m|
+      format('%<lower>s_%<upper>s', lower: m[0], upper: T.must(m[1]).downcase)
+    end.gsub(/^[A-Z]/, &:downcase)
+  end
+
+  # Method names for every operation parsed so far, in the order first seen.
+  #
+  # Read by the Tapioca compiler, which cannot otherwise see methods that
+  # `define_method_from_queries` creates per instance.
+  sig { returns(T::Array[String]) }
+  def self.operation_method_names
+    @operation_method_names ||= T.let([], T.nilable(T::Array[String]))
+  end
+
+  sig { params(queries: T.untyped).void }
+  def self.record_operations(queries)
+    queries.constants.each do |constant|
+      name = method_name_for(constant.to_s)
+      operation_method_names << name unless operation_method_names.include?(name)
+    end
+  end
+
+  # Forget operations recorded from anything but `queries.graphql`. For tests.
+  sig { void }
+  def self.reset_operations!
+    operation_method_names.clear
+    record_operations(FragmentQueries)
+  end
+
+  record_operations(FragmentQueries)
 end
 
 # A client for Fragment
@@ -127,12 +161,25 @@ class FragmentClient
     define_method_from_queries(FragmentGraphQl::FragmentQueries)
     return if extra_queries_filenames.nil?
 
-    extra_queries_filenames.each do |filename|
-      define_method_from_queries(T.let(FragmentGraphQl.parse_queries(filename), T.untyped))
-      # The per-entry-type `addLedgerEntry` operations a Schema generates arrive in
-      # exactly these files, so passing them is all a caller has to do.
-      TypedEntries.load(filename)
+    extra_queries_filenames.each { |filename| define_method_from_queries(self.class.load_queries(filename)) }
+  end
+
+  # Parse a `.graphql` document and register what can be derived from it: the
+  # operation names {FragmentClient} will answer to, and a typed payload class per
+  # Ledger Entry type it declares.
+  #
+  # Needs neither credentials nor network, so `bundle exec tapioca dsl` can see
+  # both if this runs in an initializer. {#initialize} calls it for every
+  # `extra_queries_filenames` entry, so passing the files is usually enough.
+  sig { params(paths: String).returns(T.untyped) }
+  def self.load_queries(*paths)
+    queries = paths.map do |path|
+      parsed = T.let(FragmentGraphQl.parse_queries(path), T.untyped)
+      FragmentGraphQl.record_operations(parsed)
+      TypedEntries.load(path)
+      parsed
     end
+    queries.length == 1 ? queries.first : queries
   end
 
   # Operations with a hand-written wrapper below, which the dynamic definer must
@@ -176,9 +223,7 @@ class FragmentClient
 
   def define_method_from_queries(queries)
     queries.constants.each do |qry|
-      name = qry.to_s.gsub(/[a-z]([A-Z])/) do |m|
-        format('%<lower>s_%<upper>s', lower: m[0], upper: m[1].downcase)
-      end.gsub(/^[A-Z]/, &:downcase)
+      name = FragmentGraphQl.method_name_for(qry.to_s)
 
       # Leave the hand-written wrapper in place; see WRAPPED_OPERATIONS.
       next if WRAPPED_OPERATIONS.include?(name)

--- a/lib/tapioca/dsl/compilers/fragment_query_methods.rb
+++ b/lib/tapioca/dsl/compilers/fragment_query_methods.rb
@@ -1,0 +1,58 @@
+# typed: strict
+# frozen_string_literal: true
+
+return unless defined?(Tapioca::Dsl::Compilers)
+
+require 'fragment_client'
+
+module Tapioca
+  module Dsl
+    module Compilers
+      # Declares the query and mutation methods {FragmentClient} answers to.
+      #
+      # `define_method_from_queries` creates one singleton method per operation on
+      # each client instance, so without this Sorbet reports `Method
+      # 'create_ledger' does not exist` for every one of them and a consumer has to
+      # write `T.unsafe(client)`.
+      #
+      # Covers the operations shipped in `queries.graphql`, plus any document
+      # passed to `FragmentClient.load_queries`. Operations in
+      # {FragmentClient::WRAPPED_OPERATIONS} are skipped: those have hand-written
+      # methods with real signatures already.
+      #
+      # `variables` is the operation's variables hash and stays untyped. Its keys
+      # are the GraphQL variable names verbatim, as the rest of this SDK passes
+      # them.
+      class FragmentQueryMethods < Compiler
+        extend T::Sig
+
+        ConstantType = type_member { { fixed: T.class_of(FragmentClient) } }
+
+        class << self
+          extend T::Sig
+
+          sig { override.returns(T::Enumerable[Module]) }
+          def gather_constants
+            [FragmentClient]
+          end
+        end
+
+        sig { override.void }
+        def decorate
+          names = FragmentGraphQl.operation_method_names - FragmentClient::WRAPPED_OPERATIONS
+          return if names.empty?
+
+          root.create_path(constant) do |klass|
+            names.sort.each do |name|
+              klass.create_method(
+                name,
+                parameters: [create_param('variables', type: 'T::Hash[Symbol, T.untyped]')],
+                return_type: 'T.untyped'
+              )
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/sorbet/snapshots/typed_entries.rbi
+++ b/sorbet/snapshots/typed_entries.rbi
@@ -12,6 +12,104 @@
 
 # typed: true
 
+class FragmentClient
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  def add_ledger_entry(variables); end
+
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  def add_ledger_entry_runtime(variables); end
+
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  def create_custom_currency(variables); end
+
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  def create_custom_link(variables); end
+
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  def create_ledger(variables); end
+
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  def delete_custom_txs(variables); end
+
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  def delete_ledger(variables); end
+
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  def delete_schema(variables); end
+
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  def get_account_data_migrations(variables); end
+
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  def get_entries_to_migrate_for_ledger_account_data_migration(variables); end
+
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  def get_entries_to_migrate_for_ledger_entry_data_migration(variables); end
+
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  def get_entry_data_migrations(variables); end
+
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  def get_ledger(variables); end
+
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  def get_ledger_account_balance(variables); end
+
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  def get_ledger_account_lines(variables); end
+
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  def get_ledger_entry(variables); end
+
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  def get_schema(variables); end
+
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  def get_workspace(variables); end
+
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  def list_ledger_account_balances(variables); end
+
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  def list_ledger_accounts(variables); end
+
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  def list_ledger_entries(variables); end
+
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  def list_ledger_entry_group_balances(variables); end
+
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  def list_multi_currency_ledger_account_balances(variables); end
+
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  def migrate_ledger_entry(variables); end
+
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  def reconcile_tx(variables); end
+
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  def reconcile_tx_runtime(variables); end
+
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  def reverse_ledger_entry(variables); end
+
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  def store_schema(variables); end
+
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  def sync_custom_accounts(variables); end
+
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  def sync_custom_txs(variables); end
+
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  def update_ledger(variables); end
+
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  def update_ledger_entry(variables); end
+end
+
 class FragmentClient::Entries::AuthCaptureV1 < ::FragmentClient::TypedLedgerEntry
   sig { params(ik: ::String, ledger_ik: ::String, user_id: ::String, capture_amount: ::String, posted: T.nilable(::String), description: T.nilable(::String), tags: T.nilable(T::Array[T.untyped]), groups: T.nilable(T::Array[T.untyped]), conditions: T.nilable(T::Array[T.untyped])).void }
   def initialize(ik:, ledger_ik:, user_id:, capture_amount:, posted: T.unsafe(nil), description: T.unsafe(nil), tags: T.unsafe(nil), groups: T.unsafe(nil), conditions: T.unsafe(nil)); end

--- a/sorbet/type_checks/query_methods.rb
+++ b/sorbet/type_checks/query_methods.rb
@@ -1,0 +1,33 @@
+# typed: strict
+# frozen_string_literal: true
+
+# Static assertions about the query methods. Never loaded at runtime.
+#
+# They are defined per instance by `define_method_from_queries`, so without the
+# RBI in `sorbet/snapshots/` Sorbet reports `Method 'create_ledger' does not
+# exist` for every one and a consumer has to reach for `T.unsafe`.
+#
+# `test/type_check_test.rb` covers the other direction.
+module FragmentQueryMethodChecks
+  extend T::Sig
+
+  sig { params(client: FragmentClient).returns(T.untyped) }
+  def self.queries(client)
+    client.get_ledger({ ik: 'your-ledger-ik' })
+    client.list_ledger_accounts({ ledgerIk: 'your-ledger-ik', first: 10 })
+    client.get_ledger_account_balance({ ledgerIk: 'x', path: 'assets' })
+  end
+
+  sig { params(client: FragmentClient).returns(T.untyped) }
+  def self.mutations(client)
+    client.create_ledger({ ik: 'x', ledger: { name: 'n' }, schemaKey: 'k' })
+    client.add_ledger_entry({ ik: 'x', ledgerIk: 'l', type: 't', parameters: {} })
+  end
+
+  # The batch wrapper is hand-written, so it keeps its own keyword signature
+  # rather than the generated `variables` hash.
+  sig { params(client: FragmentClient).returns(T.untyped) }
+  def self.batch(client)
+    client.add_ledger_entries(entries: [])
+  end
+end

--- a/test/add_ledger_entries_test.rb
+++ b/test/add_ledger_entries_test.rb
@@ -30,6 +30,7 @@ class AddLedgerEntriesTest < Minitest::Test
     FragmentClient.instance_variable_set(:@configuration, nil)
     FragmentClient.configure { |config| config.logger = Logger.new(File::NULL) }
     FragmentClient::TypedEntries.reset!
+    FragmentGraphQl.reset_operations!
 
     stub_request(:post, 'https://auth.fragment.dev/oauth2/token')
       .to_return(status: 200, body: { access_token: 'test_token', expires_in: 3600 }.to_json)
@@ -42,6 +43,7 @@ class AddLedgerEntriesTest < Minitest::Test
   def teardown
     @queries_file.unlink
     FragmentClient::TypedEntries.reset!
+    FragmentGraphQl.reset_operations!
     FragmentClient.instance_variable_set(:@configuration, nil)
     super
   end

--- a/test/conformance_test.rb
+++ b/test/conformance_test.rb
@@ -29,10 +29,12 @@ class ConformanceTest < Minitest::Test
     # somewhere quiet; `TypedEntriesTest` asserts on the warnings themselves.
     FragmentClient.configure { |config| config.logger = Logger.new(File::NULL) }
     FragmentClient::TypedEntries.reset!
+    FragmentGraphQl.reset_operations!
   end
 
   def teardown
     FragmentClient::TypedEntries.reset!
+    FragmentGraphQl.reset_operations!
     FragmentClient.instance_variable_set(:@configuration, nil)
     super
   end
@@ -115,10 +117,12 @@ class CanonicalKeyOrderTest < Minitest::Test
   def setup
     FragmentClient.configure { |config| config.logger = Logger.new(File::NULL) }
     FragmentClient::TypedEntries.reset!
+    FragmentGraphQl.reset_operations!
   end
 
   def teardown
     FragmentClient::TypedEntries.reset!
+    FragmentGraphQl.reset_operations!
     FragmentClient.instance_variable_set(:@configuration, nil)
     super
   end
@@ -140,6 +144,7 @@ class CanonicalKeyOrderTest < Minitest::Test
       end
 
       FragmentClient::TypedEntries.reset!
+    FragmentGraphQl.reset_operations!
     end
   end
 

--- a/test/snapshot_test.rb
+++ b/test/snapshot_test.rb
@@ -6,6 +6,7 @@ require 'logger'
 require 'minitest/autorun'
 require 'tapioca/internal'
 require 'tapioca/dsl/compilers/fragment_typed_entries'
+require 'tapioca/dsl/compilers/fragment_query_methods'
 
 # Snapshot of the RBI the Tapioca DSL compiler generates.
 #
@@ -29,6 +30,9 @@ require 'tapioca/dsl/compilers/fragment_typed_entries'
 #
 # Regenerate with `bundle exec rake snapshot` and read the diff.
 class SnapshotTest < Minitest::Test
+  COMPILERS = [Tapioca::Dsl::Compilers::FragmentTypedEntries,
+               Tapioca::Dsl::Compilers::FragmentQueryMethods].freeze
+
   FIXTURE = File.expand_path('fixtures/snapshot_entries.graphql', __dir__)
   SNAPSHOT = File.expand_path('../sorbet/snapshots/typed_entries.rbi', __dir__)
 
@@ -50,10 +54,12 @@ class SnapshotTest < Minitest::Test
   def setup
     FragmentClient.configure { |config| config.logger = Logger.new(File::NULL) }
     FragmentClient::TypedEntries.reset!
+    FragmentGraphQl.reset_operations!
   end
 
   def teardown
     FragmentClient::TypedEntries.reset!
+    FragmentGraphQl.reset_operations!
     FragmentClient.instance_variable_set(:@configuration, nil)
   end
 
@@ -93,6 +99,20 @@ class SnapshotTest < Minitest::Test
     'an optional type with no Sorbet mapping' => ->(p) { p.graphql_type == 'TransferChannel' }
   }.freeze
 
+  def test_every_shipped_operation_gets_a_method
+    # The query methods are defined per instance, so the RBI is the only thing
+    # that tells Sorbet they exist. `add_ledger_entries` is excluded because it has
+    # a hand-written signature; a duplicate declaration here would conflict.
+    rbi = self.class.generate
+
+    (FragmentGraphQl.operation_method_names - FragmentClient::WRAPPED_OPERATIONS).each do |name|
+      assert_includes rbi, "  def #{name}(variables); end", "#{name} is missing from the RBI"
+    end
+    FragmentClient::WRAPPED_OPERATIONS.each do |name|
+      refute_includes rbi, "  def #{name}(variables); end", "#{name} must not be redeclared"
+    end
+  end
+
   def test_the_fixture_exercises_every_branch_worth_snapshotting
     # A snapshot only guards what it covers. If the fixture stops reaching one of
     # these, the snapshot silently stops protecting it.
@@ -116,14 +136,18 @@ class SnapshotTest < Minitest::Test
   # drift from it.
   def self.generate
     FragmentClient::TypedEntries.reset!
+    # Tapioca memoises each compiler's constant set, and intersects it with the
+    # requested constants by identity. `reset!` above replaces the payload classes,
+    # so without this a second call in one process matches none of them.
+    COMPILERS.each(&:reset_state)
     # Into the real namespace: a class reached only through an anonymous module is
     # named `#<Module:0x...>::AuthCaptureV1`, which Sorbet cannot resolve and the
     # compiler therefore skips.
     payloads = FragmentClient::TypedEntries.load(FIXTURE)
 
     pipeline = Tapioca::Dsl::Pipeline.new(
-      requested_constants: payloads,
-      requested_compilers: [Tapioca::Dsl::Compilers::FragmentTypedEntries],
+      requested_constants: payloads + [FragmentClient],
+      requested_compilers: COMPILERS,
       # In this process rather than forked workers. Tapioca parallelises with
       # `Parallel.map(in_processes:)`, and work done in a fork is invisible to
       # both SimpleCov and any failure this test would otherwise report directly.

--- a/test/type_check_test.rb
+++ b/test/type_check_test.rb
@@ -54,6 +54,14 @@ class TypeCheckTest < Minitest::Test
       'isExternal: true, tagKeys: [], mode: :m).feeAmount.length',
       'Method `length` does not exist on `NilClass` component of `T.nilable(String)`'
     ],
+    'an operation the Schema does not declare' => [
+      "FragmentClient.new('id', 'secret').no_such_query({ ik: 'x' })",
+      'Method `no_such_query` does not exist on `FragmentClient`'
+    ],
+    'a query method given something other than a variables hash' => [
+      "FragmentClient.new('id', 'secret').create_ledger('not a hash')",
+      'for argument `variables`'
+    ],
     'a batch method given something other than an array' => [
       "FragmentClient.new('id', 'secret').add_ledger_entries(entries: 'not an array')",
       'for argument `entries`'

--- a/test/typed_entries_test.rb
+++ b/test/typed_entries_test.rb
@@ -20,10 +20,12 @@ class TypedEntriesTest < Minitest::Test
     logger.formatter = ->(_severity, _time, _progname, message) { "#{message}\n" }
     FragmentClient.configure { |config| config.logger = logger }
     FragmentClient::TypedEntries.reset!
+    FragmentGraphQl.reset_operations!
   end
 
   def teardown
     FragmentClient::TypedEntries.reset!
+    FragmentGraphQl.reset_operations!
     FragmentClient.instance_variable_set(:@configuration, nil)
     # webmock/minitest installs WebMock.reset! by aliasing Minitest::Test#teardown,
     # so a teardown here that skips super leaves its requests in the global journal.
@@ -360,6 +362,7 @@ class TypedEntriesTest < Minitest::Test
     assert_equal 'UserFundsAccountV2', only_v2.name.split('::').last
 
     FragmentClient::TypedEntries.reset!
+    FragmentGraphQl.reset_operations!
     both = load(File.read(fixture('002-type-versions', 'input.graphql')), namespace: Module.new)
 
     assert_equal 'UserFundsAccountV2', both.fetch(1).name.split('::').last


### PR DESCRIPTION
> Written by Claude, running in Steven's session — these are Claude's words and judgements, not Steven's.

Stacked on #62. This closes the gap I found when checking what a Sorbet consumer actually gets from #57 and #58.

## The problem

Every ordinary query method was invisible to Sorbet. `define_method_from_queries` creates them per instance with `define_singleton_method`, and nothing told Sorbet they exist:

```
consumer.rb:14: Method `create_ledger` does not exist on `FragmentClient`
consumer.rb:17: Method `get_ledger` does not exist on `FragmentClient`
```

All thirty-three of them, so a consumer at `typed: true` had to write `T.unsafe(client)` throughout. Half a typed SDK is a confusing thing to hand someone — the batch payloads checked, everything around them not.

## The fix

A second Tapioca compiler declares one method per operation. It cannot reflect for them, since they do not exist until a client is constructed, so `FragmentGraphQl` records the method name of every operation it parses and the compiler reads that. Operations in `WRAPPED_OPERATIONS` are skipped — those have hand-written signatures, and a second declaration would conflict.

`FragmentClient.load_queries` is the credential-free entry point that records both an operation's name and its typed payloads, so one call in an initializer is enough for `tapioca dsl` to see everything. `initialize` uses it for each `extra_queries_filenames` entry, so a caller passing their Schema's operations needs nothing further.

`variables` stays an untyped hash. Its keys are the GraphQL variable names verbatim, which is what the rest of this SDK already passes; typing each operation's variables individually is a larger change and semver-visible.

## Verified against a consumer, not just the RBI

```ruby
client.create_ledger({ ik: 'x', ledger: { name: 'n' }, schemaKey: 'k' })  # passes
client.no_such_query({ ik: 'x' })      # Method `no_such_query` does not exist
client.create_ledger('not a hash')     # Expected `T::Hash[Symbol, T.untyped]`
```

`sorbet/type_checks/query_methods.rb` holds the positive half, checked by the repository's own `srb tc`; `test/type_check_test.rb` holds the negative half. `test/snapshot_test.rb` additionally asserts every recorded operation reaches the RBI and no wrapped one is redeclared.

## One thing it surfaced

`operation_method_names` is append-only process state, which made the snapshot order-dependent as soon as a test constructed a client with extra queries. `reset_operations!` exists for that, alongside the `TypedEntries.reset!` already there. Tapioca also memoises each compiler's constant set and intersects by identity, so `reset_state` is needed between generations in one process — otherwise the second `generate` matched no payload classes and silently produced a snapshot missing all of them.

## Still not typed

Responses. `response.data.ledger.name` is untyped. That is the next piece, and it is
tractable: graphql-client already enforces at runtime that you may only read fields
the operation selected, so an RBI derived from the selection set and the schema will
agree with the runtime rather than over-promise. The open design question is union
narrowing — `... on CreateLedgerResult` means `.ledger` exists on one branch only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
