### PR TITLE
Type the response fields, so reading one is checked too

### DIFF
--- a/fragment-dev.gemspec
+++ b/fragment-dev.gemspec
@@ -23,7 +23,8 @@ Gem::Specification.new do |s|
     'lib/tapioca/dsl/helpers/graphql_sorbet_types.rb',
     # Discovered by `tapioca dsl` via `Gem.find_files`, so the paths matter.
     'lib/tapioca/dsl/compilers/fragment_typed_entries.rb',
-    'lib/tapioca/dsl/compilers/fragment_query_methods.rb'
+    'lib/tapioca/dsl/compilers/fragment_query_methods.rb',
+    'lib/tapioca/dsl/compilers/fragment_response_types.rb'
   ]
   s.required_ruby_version = '>= 3.2'
   s.summary = 'the ruby fragment client sdk'

--- a/lib/fragment_client.rb
+++ b/lib/fragment_client.rb
@@ -110,14 +110,35 @@ module FragmentGraphQl
     end
   end
 
+  # Operation ASTs by operation name, for the compilers that need a selection set
+  # rather than just a method name.
+  sig { returns(T::Hash[String, GraphQL::Language::Nodes::OperationDefinition]) }
+  def self.operations
+    @operations ||= T.let({}, T.nilable(T::Hash[String,
+                                                GraphQL::Language::Nodes::OperationDefinition]))
+  end
+
+  sig { params(source: String).void }
+  def self.record_document(source)
+    GraphQL.parse(source).definitions.each do |definition|
+      next unless definition.is_a?(GraphQL::Language::Nodes::OperationDefinition)
+
+      name = definition.name
+      operations[name] ||= definition if name
+    end
+  end
+
   # Forget operations recorded from anything but `queries.graphql`. For tests.
   sig { void }
   def self.reset_operations!
     operation_method_names.clear
+    operations.clear
     record_operations(FragmentQueries)
+    record_document(File.read("#{__dir__}/queries.graphql"))
   end
 
   record_operations(FragmentQueries)
+  record_document(File.read("#{__dir__}/queries.graphql"))
 end
 
 # A client for Fragment
@@ -174,8 +195,10 @@ class FragmentClient
   sig { params(paths: String).returns(T.untyped) }
   def self.load_queries(*paths)
     queries = paths.map do |path|
+      source = File.read(path)
       parsed = T.let(FragmentGraphQl.parse_queries(path), T.untyped)
       FragmentGraphQl.record_operations(parsed)
+      FragmentGraphQl.record_document(source)
       TypedEntries.load(path)
       parsed
     end

--- a/lib/tapioca/dsl/compilers/fragment_query_methods.rb
+++ b/lib/tapioca/dsl/compilers/fragment_query_methods.rb
@@ -22,7 +22,7 @@ module Tapioca
       #
       # `variables` is the operation's variables hash and stays untyped. Its keys
       # are the GraphQL variable names verbatim, as the rest of this SDK passes
-      # them.
+      # them. The return type comes from `FragmentResponseTypes`.
       class FragmentQueryMethods < Compiler
         extend T::Sig
 
@@ -39,15 +39,18 @@ module Tapioca
 
         sig { override.void }
         def decorate
-          names = FragmentGraphQl.operation_method_names - FragmentClient::WRAPPED_OPERATIONS
-          return if names.empty?
+          methods = FragmentGraphQl.operations.keys.to_h do |operation|
+            [FragmentGraphQl.method_name_for(operation), operation]
+          end
+          methods.reject! { |name, _| FragmentClient::WRAPPED_OPERATIONS.include?(name) }
+          return if methods.empty?
 
           root.create_path(constant) do |klass|
-            names.sort.each do |name|
+            methods.keys.sort.each do |name|
               klass.create_method(
                 name,
                 parameters: [create_param('variables', type: 'T::Hash[Symbol, T.untyped]')],
-                return_type: 'T.untyped'
+                return_type: "::FragmentClient::Responses::#{methods.fetch(name)}"
               )
             end
           end

--- a/lib/tapioca/dsl/compilers/fragment_response_types.rb
+++ b/lib/tapioca/dsl/compilers/fragment_response_types.rb
@@ -1,0 +1,222 @@
+# typed: strict
+# frozen_string_literal: true
+
+return unless defined?(Tapioca::Dsl::Compilers)
+
+require 'fragment_client'
+require 'tapioca/dsl/helpers/graphql_sorbet_types'
+
+module Tapioca
+  module Dsl
+    module Compilers
+      # Declares the response objects the query methods return, so that
+      # `client.get_ledger(...).data.ledger.name` typechecks.
+      #
+      # graphql-client builds those objects at runtime from anonymous classes whose
+      # fields are served by `method_missing`, so there is nothing to reflect on.
+      # The shape is instead derived statically from each operation's selection set
+      # and the pinned Schema -- the same two inputs graphql-client itself uses,
+      # which is what makes the declared types agree with the runtime.
+      #
+      # In particular graphql-client refuses at runtime to read a field the
+      # operation did not select (`ImplicitlyFetchedFieldError`), so a type derived
+      # from the selection set cannot promise more than the runtime allows.
+      #
+      # Emitted under `FragmentClient::Responses::<Operation>`, one nested class per
+      # selection level.
+      class FragmentResponseTypes < Compiler
+        extend T::Sig
+
+        ConstantType = type_member { { fixed: T.class_of(FragmentClient) } }
+
+        # Scalar names this Schema uses, mapped for `GraphqlSorbetTypes`.
+        SCALARS = T.let(
+          {
+            'String' => '::String', 'ID' => '::String', 'SafeString' => '::String',
+            'ParameterizedString' => '::String', 'Date' => '::String',
+            'DateTime' => '::String', 'FirstMoment' => '::String',
+            'LastMoment' => '::String', 'Period' => '::String',
+            'PeriodFilter' => '::String', 'UTCOffset' => '::String',
+            'Int96' => '::String', 'Int' => '::Integer', 'Float' => '::Float',
+            'Boolean' => 'T::Boolean', 'JSON' => 'T.untyped', 'Parameters' => 'T.untyped'
+          }.freeze,
+          T::Hash[String, String]
+        )
+
+        RESPONSES_NAMESPACE = 'FragmentClient::Responses'
+
+        class << self
+          extend T::Sig
+
+          sig { override.returns(T::Enumerable[Module]) }
+          def gather_constants
+            [FragmentClient]
+          end
+        end
+
+        sig { override.void }
+        def decorate
+          operations = FragmentGraphQl.operations
+          return if operations.empty?
+
+          root.create_module(RESPONSES_NAMESPACE) do |namespace|
+            operations.keys.sort.each do |name|
+              declare_operation(namespace, name, T.must(operations[name]))
+            end
+          end
+        end
+
+        private
+
+        sig do
+          params(namespace: RBI::Scope, name: String,
+                 operation: GraphQL::Language::Nodes::OperationDefinition).void
+        end
+        def declare_operation(namespace, name, operation)
+          root_type = operation.operation_type == 'mutation' ? schema.mutation : schema.query
+          return if root_type.nil?
+
+          namespace.create_class(name) do |response|
+            response.create_method('data', return_type: "T.nilable(#{RESPONSES_NAMESPACE}::#{name}::Data)")
+            response.create_method('errors', return_type: 'T.untyped')
+            response.create_method('original_hash', return_type: 'T::Hash[String, T.untyped]')
+            declare_object(response, 'Data', operation.selections, root_type)
+          end
+        end
+
+        # One nested class per selection level. `path` is its fully qualified name,
+        # which children extend so nested references resolve.
+        sig do
+          params(parent: RBI::Scope, class_name: String, selections: T::Array[T.untyped],
+                 graphql_type: T.untyped).void
+        end
+        def declare_object(parent, class_name, selections, graphql_type)
+          fields = collect_fields(selections, graphql_type)
+
+          parent.create_class(class_name) do |scope|
+            fields.each do |field|
+              scope.create_method(field.fetch(:method), return_type: field.fetch(:type),
+                                                        comments: field.fetch(:comments))
+              nested = field[:nested]
+              next unless nested
+
+              declare_object(scope, nested.fetch(:class_name), nested.fetch(:selections),
+                             nested.fetch(:type))
+            end
+          end
+        end
+
+        # Flatten a selection set into field descriptors, following inline fragments.
+        #
+        # A union or interface selection contributes every branch's fields, each
+        # made nilable: graphql-client returns one object whatever the `__typename`,
+        # and only the branch that matched carries values.
+        sig do
+          params(selections: T::Array[T.untyped], graphql_type: T.untyped, force_nilable: T::Boolean,
+                 taken: T::Set[String])
+            .returns(T::Array[T::Hash[Symbol, T.untyped]])
+        end
+        def collect_fields(selections, graphql_type, force_nilable: false, taken: Set.new)
+          selections.flat_map do |selection|
+            case selection
+            when GraphQL::Language::Nodes::Field
+              field = describe_field(selection, graphql_type, force_nilable, taken)
+              field ? [field] : []
+            when GraphQL::Language::Nodes::InlineFragment
+              branch = selection.type ? lookup_type(selection.type.name) : graphql_type
+              next [] if branch.nil?
+
+              collect_fields(selection.selections, branch, force_nilable: true, taken: taken)
+            else
+              []
+            end
+          end
+        end
+
+        sig do
+          params(selection: GraphQL::Language::Nodes::Field, graphql_type: T.untyped,
+                 force_nilable: T::Boolean, taken: T::Set[String])
+            .returns(T.nilable(T::Hash[Symbol, T.untyped]))
+        end
+        def describe_field(selection, graphql_type, force_nilable, taken)
+          name = selection.alias || selection.name
+          method = ActiveSupport::Inflector.underscore(name)
+          return nil if taken.include?(method)
+
+          taken << method
+          return { method: method, type: '::String', comments: [], nested: nil } if name == '__typename'
+
+          field = graphql_type.respond_to?(:fields) ? graphql_type.fields[selection.name] : nil
+          return { method: method, type: 'T.untyped', comments: [], nested: nil } if field.nil?
+
+          build_field(selection, field, method, name, force_nilable, taken)
+        end
+
+        sig do
+          params(selection: GraphQL::Language::Nodes::Field, field: T.untyped, method: String,
+                 name: String, force_nilable: T::Boolean, taken: T::Set[String])
+            .returns(T::Hash[Symbol, T.untyped])
+        end
+        def build_field(selection, field, method, name, force_nilable, taken)
+          unwrapped = field.type.unwrap
+          nilable = force_nilable || !field.type.non_null?
+
+          if selection.selections.empty?
+            return { method: method, type: wrap(scalar_type(unwrapped), field.type, nilable),
+                     comments: [comment("`#{name}`: #{field.type.to_type_signature}")], nested: nil }
+          end
+
+          class_name = ActiveSupport::Inflector.camelize(method)
+          class_name = "#{class_name}Object" if taken.include?("class:#{class_name}")
+          taken << "class:#{class_name}"
+
+          { method: method, type: wrap(class_name, field.type, nilable),
+            comments: [comment("`#{name}`: #{field.type.to_type_signature}")],
+            nested: { class_name: class_name, selections: selection.selections,
+                      type: unwrapped } }
+        end
+
+        # Apply the GraphQL type's list and nullability wrappers to `inner`.
+        #
+        # `[Ledger!]!` becomes `T::Array[X]`, `[Ledger]` becomes
+        # `T::Array[T.nilable(X)]`. `T.untyped` already includes nil, so it is never
+        # wrapped again.
+        sig { params(inner: String, graphql_type: T.untyped, nilable: T::Boolean).returns(String) }
+        def wrap(inner, graphql_type, nilable)
+          bare = graphql_type.non_null? ? graphql_type.of_type : graphql_type
+          type = if bare.list?
+                   "T::Array[#{nilable_unless(inner, bare.of_type.non_null?)}]"
+                 else
+                   inner
+                 end
+          nilable_unless(type, !nilable)
+        end
+
+        sig { params(type: String, non_null: T::Boolean).returns(String) }
+        def nilable_unless(type, non_null)
+          non_null || type == 'T.untyped' ? type : "T.nilable(#{type})"
+        end
+
+        sig { params(unwrapped: T.untyped).returns(String) }
+        def scalar_type(unwrapped)
+          Helpers::GraphqlSorbetTypes.translate(unwrapped.graphql_name, scalars: SCALARS)
+        end
+
+        sig { params(name: String).returns(T.untyped) }
+        def lookup_type(name)
+          schema.types[name]
+        end
+
+        sig { returns(T.untyped) }
+        def schema
+          FragmentGraphQl::FragmentSchema
+        end
+
+        sig { params(text: String).returns(RBI::Comment) }
+        def comment(text)
+          RBI::Comment.new(text)
+        end
+      end
+    end
+  end
+end

--- a/sorbet/snapshots/typed_entries.rbi
+++ b/sorbet/snapshots/typed_entries.rbi
@@ -13,101 +13,3130 @@
 # typed: true
 
 class FragmentClient
-  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(::FragmentClient::Responses::AddLedgerEntry) }
   def add_ledger_entry(variables); end
 
-  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(::FragmentClient::Responses::AddLedgerEntryRuntime) }
   def add_ledger_entry_runtime(variables); end
 
-  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(::FragmentClient::Responses::CreateCustomCurrency) }
   def create_custom_currency(variables); end
 
-  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(::FragmentClient::Responses::CreateCustomLink) }
   def create_custom_link(variables); end
 
-  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(::FragmentClient::Responses::CreateLedger) }
   def create_ledger(variables); end
 
-  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(::FragmentClient::Responses::DeleteCustomTxs) }
   def delete_custom_txs(variables); end
 
-  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(::FragmentClient::Responses::DeleteLedger) }
   def delete_ledger(variables); end
 
-  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(::FragmentClient::Responses::DeleteSchema) }
   def delete_schema(variables); end
 
-  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(::FragmentClient::Responses::GetAccountDataMigrations) }
   def get_account_data_migrations(variables); end
 
-  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(::FragmentClient::Responses::GetEntriesToMigrateForLedgerAccountDataMigration) }
   def get_entries_to_migrate_for_ledger_account_data_migration(variables); end
 
-  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(::FragmentClient::Responses::GetEntriesToMigrateForLedgerEntryDataMigration) }
   def get_entries_to_migrate_for_ledger_entry_data_migration(variables); end
 
-  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(::FragmentClient::Responses::GetEntryDataMigrations) }
   def get_entry_data_migrations(variables); end
 
-  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(::FragmentClient::Responses::GetLedger) }
   def get_ledger(variables); end
 
-  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(::FragmentClient::Responses::GetLedgerAccountBalance) }
   def get_ledger_account_balance(variables); end
 
-  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(::FragmentClient::Responses::GetLedgerAccountLines) }
   def get_ledger_account_lines(variables); end
 
-  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(::FragmentClient::Responses::GetLedgerEntry) }
   def get_ledger_entry(variables); end
 
-  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(::FragmentClient::Responses::GetSchema) }
   def get_schema(variables); end
 
-  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(::FragmentClient::Responses::GetWorkspace) }
   def get_workspace(variables); end
 
-  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(::FragmentClient::Responses::ListLedgerAccountBalances) }
   def list_ledger_account_balances(variables); end
 
-  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(::FragmentClient::Responses::ListLedgerAccounts) }
   def list_ledger_accounts(variables); end
 
-  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(::FragmentClient::Responses::ListLedgerEntries) }
   def list_ledger_entries(variables); end
 
-  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(::FragmentClient::Responses::ListLedgerEntryGroupBalances) }
   def list_ledger_entry_group_balances(variables); end
 
-  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(::FragmentClient::Responses::ListMultiCurrencyLedgerAccountBalances) }
   def list_multi_currency_ledger_account_balances(variables); end
 
-  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(::FragmentClient::Responses::MigrateLedgerEntry) }
   def migrate_ledger_entry(variables); end
 
-  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(::FragmentClient::Responses::ReconcileTx) }
   def reconcile_tx(variables); end
 
-  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(::FragmentClient::Responses::ReconcileTxRuntime) }
   def reconcile_tx_runtime(variables); end
 
-  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(::FragmentClient::Responses::ReverseLedgerEntry) }
   def reverse_ledger_entry(variables); end
 
-  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(::FragmentClient::Responses::StoreSchema) }
   def store_schema(variables); end
 
-  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(::FragmentClient::Responses::SyncCustomAccounts) }
   def sync_custom_accounts(variables); end
 
-  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(::FragmentClient::Responses::SyncCustomTxs) }
   def sync_custom_txs(variables); end
 
-  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(::FragmentClient::Responses::UpdateLedger) }
   def update_ledger(variables); end
 
-  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
+  sig { params(variables: T::Hash[Symbol, T.untyped]).returns(::FragmentClient::Responses::UpdateLedgerEntry) }
   def update_ledger_entry(variables); end
+end
+
+module FragmentClient::Responses
+  class AddLedgerEntries
+    sig { returns(T.nilable(FragmentClient::Responses::AddLedgerEntries::Data)) }
+    def data; end
+
+    sig { returns(T.untyped) }
+    def errors; end
+
+    sig { returns(T::Hash[String, T.untyped]) }
+    def original_hash; end
+
+    class Data
+      # `addLedgerEntries`: AddLedgerEntriesResponse!
+      sig { returns(AddLedgerEntries) }
+      def add_ledger_entries; end
+
+      class AddLedgerEntries
+        sig { returns(::String) }
+        def __typename; end
+
+        # `results`: [AddLedgerEntryResult!]!
+        sig { returns(T.nilable(T::Array[Results])) }
+        def results; end
+
+        class Results
+          # `isIkReplay`: Boolean!
+          sig { returns(T::Boolean) }
+          def is_ik_replay; end
+
+          # `entry`: LedgerEntry!
+          sig { returns(Entry) }
+          def entry; end
+
+          class Entry
+            # `type`: SafeString
+            sig { returns(T.nilable(::String)) }
+            def type; end
+
+            # `id`: ID!
+            sig { returns(::String) }
+            def id; end
+
+            # `ik`: String!
+            sig { returns(::String) }
+            def ik; end
+
+            # `posted`: DateTime!
+            sig { returns(::String) }
+            def posted; end
+
+            # `created`: DateTime!
+            sig { returns(::String) }
+            def created; end
+          end
+
+          # `lines`: [LedgerLine!]!
+          sig { returns(T::Array[Lines]) }
+          def lines; end
+
+          class Lines
+            # `id`: ID!
+            sig { returns(::String) }
+            def id; end
+
+            # `amount`: Int96!
+            sig { returns(::String) }
+            def amount; end
+
+            # `account`: LedgerAccount!
+            sig { returns(Account) }
+            def account; end
+
+            class Account
+              # `path`: String!
+              sig { returns(::String) }
+              def path; end
+            end
+          end
+        end
+
+        # `code`: String!
+        sig { returns(T.nilable(::String)) }
+        def code; end
+
+        # `message`: String!
+        sig { returns(T.nilable(::String)) }
+        def message; end
+
+        # `retryable`: Boolean!
+        sig { returns(T.nilable(T::Boolean)) }
+        def retryable; end
+
+        # `errors`: [AddLedgerEntryError!]!
+        sig { returns(T.nilable(T::Array[Errors])) }
+        def errors; end
+
+        class Errors
+          # `ik`: SafeString!
+          sig { returns(::String) }
+          def ik; end
+
+          # `code`: String!
+          sig { returns(::String) }
+          def code; end
+
+          # `message`: String!
+          sig { returns(::String) }
+          def message; end
+
+          # `retryable`: Boolean!
+          sig { returns(T::Boolean) }
+          def retryable; end
+        end
+      end
+    end
+  end
+
+  class AddLedgerEntry
+    sig { returns(T.nilable(FragmentClient::Responses::AddLedgerEntry::Data)) }
+    def data; end
+
+    sig { returns(T.untyped) }
+    def errors; end
+
+    sig { returns(T::Hash[String, T.untyped]) }
+    def original_hash; end
+
+    class Data
+      # `addLedgerEntry`: AddLedgerEntryResponse!
+      sig { returns(AddLedgerEntry) }
+      def add_ledger_entry; end
+
+      class AddLedgerEntry
+        sig { returns(::String) }
+        def __typename; end
+
+        # `isIkReplay`: Boolean!
+        sig { returns(T.nilable(T::Boolean)) }
+        def is_ik_replay; end
+
+        # `entry`: LedgerEntry!
+        sig { returns(T.nilable(Entry)) }
+        def entry; end
+
+        class Entry
+          # `type`: SafeString
+          sig { returns(T.nilable(::String)) }
+          def type; end
+
+          # `id`: ID!
+          sig { returns(::String) }
+          def id; end
+
+          # `ik`: String!
+          sig { returns(::String) }
+          def ik; end
+
+          # `posted`: DateTime!
+          sig { returns(::String) }
+          def posted; end
+
+          # `created`: DateTime!
+          sig { returns(::String) }
+          def created; end
+        end
+
+        # `lines`: [LedgerLine!]!
+        sig { returns(T.nilable(T::Array[Lines])) }
+        def lines; end
+
+        class Lines
+          # `id`: ID!
+          sig { returns(::String) }
+          def id; end
+
+          # `amount`: Int96!
+          sig { returns(::String) }
+          def amount; end
+
+          # `account`: LedgerAccount!
+          sig { returns(Account) }
+          def account; end
+
+          class Account
+            # `path`: String!
+            sig { returns(::String) }
+            def path; end
+          end
+        end
+
+        # `code`: String!
+        sig { returns(T.nilable(::String)) }
+        def code; end
+
+        # `message`: String!
+        sig { returns(T.nilable(::String)) }
+        def message; end
+
+        # `retryable`: Boolean!
+        sig { returns(T.nilable(T::Boolean)) }
+        def retryable; end
+      end
+    end
+  end
+
+  class AddLedgerEntryRuntime
+    sig { returns(T.nilable(FragmentClient::Responses::AddLedgerEntryRuntime::Data)) }
+    def data; end
+
+    sig { returns(T.untyped) }
+    def errors; end
+
+    sig { returns(T::Hash[String, T.untyped]) }
+    def original_hash; end
+
+    class Data
+      # `addLedgerEntry`: AddLedgerEntryResponse!
+      sig { returns(AddLedgerEntry) }
+      def add_ledger_entry; end
+
+      class AddLedgerEntry
+        sig { returns(::String) }
+        def __typename; end
+
+        # `isIkReplay`: Boolean!
+        sig { returns(T.nilable(T::Boolean)) }
+        def is_ik_replay; end
+
+        # `entry`: LedgerEntry!
+        sig { returns(T.nilable(Entry)) }
+        def entry; end
+
+        class Entry
+          # `type`: SafeString
+          sig { returns(T.nilable(::String)) }
+          def type; end
+
+          # `id`: ID!
+          sig { returns(::String) }
+          def id; end
+
+          # `ik`: String!
+          sig { returns(::String) }
+          def ik; end
+
+          # `posted`: DateTime!
+          sig { returns(::String) }
+          def posted; end
+
+          # `created`: DateTime!
+          sig { returns(::String) }
+          def created; end
+        end
+
+        # `lines`: [LedgerLine!]!
+        sig { returns(T.nilable(T::Array[Lines])) }
+        def lines; end
+
+        class Lines
+          # `id`: ID!
+          sig { returns(::String) }
+          def id; end
+
+          # `amount`: Int96!
+          sig { returns(::String) }
+          def amount; end
+
+          # `account`: LedgerAccount!
+          sig { returns(Account) }
+          def account; end
+
+          class Account
+            # `path`: String!
+            sig { returns(::String) }
+            def path; end
+          end
+        end
+
+        # `code`: String!
+        sig { returns(T.nilable(::String)) }
+        def code; end
+
+        # `message`: String!
+        sig { returns(T.nilable(::String)) }
+        def message; end
+
+        # `retryable`: Boolean!
+        sig { returns(T.nilable(T::Boolean)) }
+        def retryable; end
+      end
+    end
+  end
+
+  class CreateCustomCurrency
+    sig { returns(T.nilable(FragmentClient::Responses::CreateCustomCurrency::Data)) }
+    def data; end
+
+    sig { returns(T.untyped) }
+    def errors; end
+
+    sig { returns(T::Hash[String, T.untyped]) }
+    def original_hash; end
+
+    class Data
+      # `createCustomCurrency`: CreateCustomCurrencyResponse!
+      sig { returns(CreateCustomCurrency) }
+      def create_custom_currency; end
+
+      class CreateCustomCurrency
+        # `customCurrency`: Currency!
+        sig { returns(T.nilable(CustomCurrency)) }
+        def custom_currency; end
+
+        class CustomCurrency
+          # `code`: CurrencyCode!
+          sig { returns(T.untyped) }
+          def code; end
+
+          # `customCurrencyId`: SafeString
+          sig { returns(T.nilable(::String)) }
+          def custom_currency_id; end
+
+          # `precision`: Int!
+          sig { returns(::Integer) }
+          def precision; end
+
+          # `name`: String!
+          sig { returns(::String) }
+          def name; end
+
+          # `customCode`: String
+          sig { returns(T.nilable(::String)) }
+          def custom_code; end
+        end
+
+        # `code`: String!
+        sig { returns(T.nilable(::String)) }
+        def code; end
+
+        # `message`: String!
+        sig { returns(T.nilable(::String)) }
+        def message; end
+
+        # `retryable`: Boolean!
+        sig { returns(T.nilable(T::Boolean)) }
+        def retryable; end
+      end
+    end
+  end
+
+  class CreateCustomLink
+    sig { returns(T.nilable(FragmentClient::Responses::CreateCustomLink::Data)) }
+    def data; end
+
+    sig { returns(T.untyped) }
+    def errors; end
+
+    sig { returns(T::Hash[String, T.untyped]) }
+    def original_hash; end
+
+    class Data
+      # `createCustomLink`: CreateCustomLinkResponse!
+      sig { returns(CreateCustomLink) }
+      def create_custom_link; end
+
+      class CreateCustomLink
+        sig { returns(::String) }
+        def __typename; end
+
+        # `link`: CustomLink!
+        sig { returns(T.nilable(Link)) }
+        def link; end
+
+        class Link
+          # `id`: ID!
+          sig { returns(::String) }
+          def id; end
+
+          # `name`: String!
+          sig { returns(::String) }
+          def name; end
+
+          # `created`: String!
+          sig { returns(::String) }
+          def created; end
+        end
+
+        # `isIkReplay`: Boolean!
+        sig { returns(T.nilable(T::Boolean)) }
+        def is_ik_replay; end
+
+        # `code`: String!
+        sig { returns(T.nilable(::String)) }
+        def code; end
+
+        # `message`: String!
+        sig { returns(T.nilable(::String)) }
+        def message; end
+
+        # `retryable`: Boolean!
+        sig { returns(T.nilable(T::Boolean)) }
+        def retryable; end
+      end
+    end
+  end
+
+  class CreateLedger
+    sig { returns(T.nilable(FragmentClient::Responses::CreateLedger::Data)) }
+    def data; end
+
+    sig { returns(T.untyped) }
+    def errors; end
+
+    sig { returns(T::Hash[String, T.untyped]) }
+    def original_hash; end
+
+    class Data
+      # `createLedger`: CreateLedgerResponse!
+      sig { returns(CreateLedger) }
+      def create_ledger; end
+
+      class CreateLedger
+        sig { returns(::String) }
+        def __typename; end
+
+        # `ledger`: Ledger!
+        sig { returns(T.nilable(Ledger)) }
+        def ledger; end
+
+        class Ledger
+          # `id`: ID!
+          sig { returns(::String) }
+          def id; end
+
+          # `ik`: SafeString!
+          sig { returns(::String) }
+          def ik; end
+
+          # `name`: String!
+          sig { returns(::String) }
+          def name; end
+
+          # `created`: DateTime!
+          sig { returns(::String) }
+          def created; end
+
+          # `schema`: Schema
+          sig { returns(T.nilable(Schema)) }
+          def schema; end
+
+          class Schema
+            # `key`: SafeString!
+            sig { returns(::String) }
+            def key; end
+          end
+        end
+
+        # `isIkReplay`: Boolean!
+        sig { returns(T.nilable(T::Boolean)) }
+        def is_ik_replay; end
+
+        # `code`: String!
+        sig { returns(T.nilable(::String)) }
+        def code; end
+
+        # `message`: String!
+        sig { returns(T.nilable(::String)) }
+        def message; end
+
+        # `retryable`: Boolean!
+        sig { returns(T.nilable(T::Boolean)) }
+        def retryable; end
+      end
+    end
+  end
+
+  class DeleteCustomTxs
+    sig { returns(T.nilable(FragmentClient::Responses::DeleteCustomTxs::Data)) }
+    def data; end
+
+    sig { returns(T.untyped) }
+    def errors; end
+
+    sig { returns(T::Hash[String, T.untyped]) }
+    def original_hash; end
+
+    class Data
+      # `deleteCustomTxs`: DeleteCustomTxsResponse!
+      sig { returns(DeleteCustomTxs) }
+      def delete_custom_txs; end
+
+      class DeleteCustomTxs
+        sig { returns(::String) }
+        def __typename; end
+
+        # `txs`: [DeletedCustomTx!]!
+        sig { returns(T.nilable(T::Array[Txs])) }
+        def txs; end
+
+        class Txs
+          # `tx`: Tx!
+          sig { returns(Tx) }
+          def tx; end
+
+          class Tx
+            # `linkId`: ID!
+            sig { returns(::String) }
+            def link_id; end
+
+            # `id`: ID!
+            sig { returns(::String) }
+            def id; end
+
+            # `externalId`: ID!
+            sig { returns(::String) }
+            def external_id; end
+
+            # `externalAccountId`: ID!
+            sig { returns(::String) }
+            def external_account_id; end
+
+            # `amount`: Int96!
+            sig { returns(::String) }
+            def amount; end
+
+            # `description`: String!
+            sig { returns(::String) }
+            def description; end
+
+            # `posted`: DateTime!
+            sig { returns(::String) }
+            def posted; end
+
+            # `deletedAt`: DateTime
+            sig { returns(T.nilable(::String)) }
+            def deleted_at; end
+          end
+        end
+
+        # `code`: String!
+        sig { returns(T.nilable(::String)) }
+        def code; end
+
+        # `message`: String!
+        sig { returns(T.nilable(::String)) }
+        def message; end
+
+        # `retryable`: Boolean!
+        sig { returns(T.nilable(T::Boolean)) }
+        def retryable; end
+      end
+    end
+  end
+
+  class DeleteLedger
+    sig { returns(T.nilable(FragmentClient::Responses::DeleteLedger::Data)) }
+    def data; end
+
+    sig { returns(T.untyped) }
+    def errors; end
+
+    sig { returns(T::Hash[String, T.untyped]) }
+    def original_hash; end
+
+    class Data
+      # `deleteLedger`: DeleteLedgerResponse!
+      sig { returns(DeleteLedger) }
+      def delete_ledger; end
+
+      class DeleteLedger
+        sig { returns(::String) }
+        def __typename; end
+
+        # `success`: Boolean!
+        sig { returns(T.nilable(T::Boolean)) }
+        def success; end
+
+        # `code`: String!
+        sig { returns(T.nilable(::String)) }
+        def code; end
+
+        # `message`: String!
+        sig { returns(T.nilable(::String)) }
+        def message; end
+
+        # `retryable`: Boolean!
+        sig { returns(T.nilable(T::Boolean)) }
+        def retryable; end
+      end
+    end
+  end
+
+  class DeleteSchema
+    sig { returns(T.nilable(FragmentClient::Responses::DeleteSchema::Data)) }
+    def data; end
+
+    sig { returns(T.untyped) }
+    def errors; end
+
+    sig { returns(T::Hash[String, T.untyped]) }
+    def original_hash; end
+
+    class Data
+      # `deleteSchema`: DeleteSchemaResponse!
+      sig { returns(DeleteSchema) }
+      def delete_schema; end
+
+      class DeleteSchema
+        sig { returns(::String) }
+        def __typename; end
+
+        # `success`: Boolean!
+        sig { returns(T.nilable(T::Boolean)) }
+        def success; end
+
+        # `code`: String!
+        sig { returns(T.nilable(::String)) }
+        def code; end
+
+        # `message`: String!
+        sig { returns(T.nilable(::String)) }
+        def message; end
+
+        # `retryable`: Boolean!
+        sig { returns(T.nilable(T::Boolean)) }
+        def retryable; end
+      end
+    end
+  end
+
+  class GetAccountDataMigrations
+    sig { returns(T.nilable(FragmentClient::Responses::GetAccountDataMigrations::Data)) }
+    def data; end
+
+    sig { returns(T.untyped) }
+    def errors; end
+
+    sig { returns(T::Hash[String, T.untyped]) }
+    def original_hash; end
+
+    class Data
+      # `ledger`: Ledger
+      sig { returns(T.nilable(Ledger)) }
+      def ledger; end
+
+      class Ledger
+        # `ledgerAccountDataMigrations`: LedgerAccountDataMigrationConnection!
+        sig { returns(LedgerAccountDataMigrations) }
+        def ledger_account_data_migrations; end
+
+        class LedgerAccountDataMigrations
+          # `nodes`: [LedgerAccountDataMigration!]!
+          sig { returns(T::Array[Nodes]) }
+          def nodes; end
+
+          class Nodes
+            # `accountPath`: String!
+            sig { returns(::String) }
+            def account_path; end
+
+            # `status`: LedgerDataMigrationStatus!
+            sig { returns(T.untyped) }
+            def status; end
+
+            # `currentMigration`: LedgerDataMigrationHistoryEntry
+            sig { returns(T.nilable(CurrentMigration)) }
+            def current_migration; end
+
+            class CurrentMigration
+              # `schemaVersion`: Int!
+              sig { returns(::Integer) }
+              def schema_version; end
+
+              # `status`: LedgerDataMigrationStatus!
+              sig { returns(T.untyped) }
+              def status; end
+            end
+
+            # `ledgerEntries`: LedgerEntriesConnection!
+            sig { returns(LedgerEntries) }
+            def ledger_entries; end
+
+            class LedgerEntries
+              # `nodes`: [LedgerEntry!]!
+              sig { returns(T::Array[Nodes]) }
+              def nodes; end
+
+              class Nodes
+                # `id`: ID!
+                sig { returns(::String) }
+                def id; end
+
+                # `type`: SafeString
+                sig { returns(T.nilable(::String)) }
+                def type; end
+
+                # `posted`: DateTime!
+                sig { returns(::String) }
+                def posted; end
+
+                # `parameters`: Parameters
+                sig { returns(T.untyped) }
+                def parameters; end
+              end
+
+              # `pageInfo`: PageInfo!
+              sig { returns(PageInfo) }
+              def page_info; end
+
+              class PageInfo
+                # `hasNextPage`: Boolean!
+                sig { returns(T::Boolean) }
+                def has_next_page; end
+
+                # `endCursor`: String
+                sig { returns(T.nilable(::String)) }
+                def end_cursor; end
+
+                # `hasPreviousPage`: Boolean!
+                sig { returns(T::Boolean) }
+                def has_previous_page; end
+
+                # `startCursor`: String
+                sig { returns(T.nilable(::String)) }
+                def start_cursor; end
+              end
+            end
+
+            # `history`: LedgerDataMigrationHistoryConnection!
+            sig { returns(History) }
+            def history; end
+
+            class History
+              # `nodes`: [LedgerDataMigrationHistoryEntry!]!
+              sig { returns(T::Array[Nodes]) }
+              def nodes; end
+
+              class Nodes
+                # `schemaVersion`: Int!
+                sig { returns(::Integer) }
+                def schema_version; end
+
+                # `status`: LedgerDataMigrationStatus!
+                sig { returns(T.untyped) }
+                def status; end
+              end
+
+              # `pageInfo`: PageInfo!
+              sig { returns(PageInfo) }
+              def page_info; end
+
+              class PageInfo
+                # `hasNextPage`: Boolean!
+                sig { returns(T::Boolean) }
+                def has_next_page; end
+
+                # `endCursor`: String
+                sig { returns(T.nilable(::String)) }
+                def end_cursor; end
+
+                # `hasPreviousPage`: Boolean!
+                sig { returns(T::Boolean) }
+                def has_previous_page; end
+
+                # `startCursor`: String
+                sig { returns(T.nilable(::String)) }
+                def start_cursor; end
+              end
+            end
+          end
+
+          # `pageInfo`: PageInfo!
+          sig { returns(PageInfo) }
+          def page_info; end
+
+          class PageInfo
+            # `hasNextPage`: Boolean!
+            sig { returns(T::Boolean) }
+            def has_next_page; end
+
+            # `endCursor`: String
+            sig { returns(T.nilable(::String)) }
+            def end_cursor; end
+
+            # `hasPreviousPage`: Boolean!
+            sig { returns(T::Boolean) }
+            def has_previous_page; end
+
+            # `startCursor`: String
+            sig { returns(T.nilable(::String)) }
+            def start_cursor; end
+          end
+        end
+      end
+    end
+  end
+
+  class GetEntriesToMigrateForLedgerAccountDataMigration
+    sig { returns(T.nilable(FragmentClient::Responses::GetEntriesToMigrateForLedgerAccountDataMigration::Data)) }
+    def data; end
+
+    sig { returns(T.untyped) }
+    def errors; end
+
+    sig { returns(T::Hash[String, T.untyped]) }
+    def original_hash; end
+
+    class Data
+      # `ledger`: Ledger
+      sig { returns(T.nilable(Ledger)) }
+      def ledger; end
+
+      class Ledger
+        # `ledgerAccountDataMigrations`: LedgerAccountDataMigrationConnection!
+        sig { returns(LedgerAccountDataMigrations) }
+        def ledger_account_data_migrations; end
+
+        class LedgerAccountDataMigrations
+          # `nodes`: [LedgerAccountDataMigration!]!
+          sig { returns(T::Array[Nodes]) }
+          def nodes; end
+
+          class Nodes
+            # `ledgerEntries`: LedgerEntriesConnection!
+            sig { returns(LedgerEntries) }
+            def ledger_entries; end
+
+            class LedgerEntries
+              # `nodes`: [LedgerEntry!]!
+              sig { returns(T::Array[Nodes]) }
+              def nodes; end
+
+              class Nodes
+                # `id`: ID!
+                sig { returns(::String) }
+                def id; end
+
+                # `ik`: String!
+                sig { returns(::String) }
+                def ik; end
+
+                # `type`: SafeString
+                sig { returns(T.nilable(::String)) }
+                def type; end
+
+                # `typeVersion`: Int
+                sig { returns(T.nilable(::Integer)) }
+                def type_version; end
+
+                # `description`: String
+                sig { returns(T.nilable(::String)) }
+                def description; end
+
+                # `posted`: DateTime!
+                sig { returns(::String) }
+                def posted; end
+
+                # `created`: DateTime!
+                sig { returns(::String) }
+                def created; end
+
+                # `parameters`: Parameters
+                sig { returns(T.untyped) }
+                def parameters; end
+
+                # `lines`: LedgerLinesConnection!
+                sig { returns(Lines) }
+                def lines; end
+
+                class Lines
+                  # `nodes`: [LedgerLine!]!
+                  sig { returns(T::Array[Nodes]) }
+                  def nodes; end
+
+                  class Nodes
+                    # `id`: ID!
+                    sig { returns(::String) }
+                    def id; end
+
+                    # `amount`: Int96!
+                    sig { returns(::String) }
+                    def amount; end
+
+                    # `account`: LedgerAccount!
+                    sig { returns(Account) }
+                    def account; end
+
+                    class Account
+                      # `path`: String!
+                      sig { returns(::String) }
+                      def path; end
+                    end
+                  end
+                end
+              end
+
+              # `pageInfo`: PageInfo!
+              sig { returns(PageInfo) }
+              def page_info; end
+
+              class PageInfo
+                # `hasNextPage`: Boolean!
+                sig { returns(T::Boolean) }
+                def has_next_page; end
+
+                # `endCursor`: String
+                sig { returns(T.nilable(::String)) }
+                def end_cursor; end
+
+                # `hasPreviousPage`: Boolean!
+                sig { returns(T::Boolean) }
+                def has_previous_page; end
+
+                # `startCursor`: String
+                sig { returns(T.nilable(::String)) }
+                def start_cursor; end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+
+  class GetEntriesToMigrateForLedgerEntryDataMigration
+    sig { returns(T.nilable(FragmentClient::Responses::GetEntriesToMigrateForLedgerEntryDataMigration::Data)) }
+    def data; end
+
+    sig { returns(T.untyped) }
+    def errors; end
+
+    sig { returns(T::Hash[String, T.untyped]) }
+    def original_hash; end
+
+    class Data
+      # `ledger`: Ledger
+      sig { returns(T.nilable(Ledger)) }
+      def ledger; end
+
+      class Ledger
+        # `ledgerEntryDataMigrations`: LedgerEntryDataMigrationConnection!
+        sig { returns(LedgerEntryDataMigrations) }
+        def ledger_entry_data_migrations; end
+
+        class LedgerEntryDataMigrations
+          # `nodes`: [LedgerEntryDataMigration!]!
+          sig { returns(T::Array[Nodes]) }
+          def nodes; end
+
+          class Nodes
+            # `ledgerEntries`: LedgerEntriesConnection!
+            sig { returns(LedgerEntries) }
+            def ledger_entries; end
+
+            class LedgerEntries
+              # `nodes`: [LedgerEntry!]!
+              sig { returns(T::Array[Nodes]) }
+              def nodes; end
+
+              class Nodes
+                # `id`: ID!
+                sig { returns(::String) }
+                def id; end
+
+                # `ik`: String!
+                sig { returns(::String) }
+                def ik; end
+
+                # `type`: SafeString
+                sig { returns(T.nilable(::String)) }
+                def type; end
+
+                # `typeVersion`: Int
+                sig { returns(T.nilable(::Integer)) }
+                def type_version; end
+
+                # `description`: String
+                sig { returns(T.nilable(::String)) }
+                def description; end
+
+                # `posted`: DateTime!
+                sig { returns(::String) }
+                def posted; end
+
+                # `created`: DateTime!
+                sig { returns(::String) }
+                def created; end
+
+                # `parameters`: Parameters
+                sig { returns(T.untyped) }
+                def parameters; end
+
+                # `lines`: LedgerLinesConnection!
+                sig { returns(Lines) }
+                def lines; end
+
+                class Lines
+                  # `nodes`: [LedgerLine!]!
+                  sig { returns(T::Array[Nodes]) }
+                  def nodes; end
+
+                  class Nodes
+                    # `id`: ID!
+                    sig { returns(::String) }
+                    def id; end
+
+                    # `amount`: Int96!
+                    sig { returns(::String) }
+                    def amount; end
+
+                    # `account`: LedgerAccount!
+                    sig { returns(Account) }
+                    def account; end
+
+                    class Account
+                      # `path`: String!
+                      sig { returns(::String) }
+                      def path; end
+                    end
+                  end
+                end
+              end
+
+              # `pageInfo`: PageInfo!
+              sig { returns(PageInfo) }
+              def page_info; end
+
+              class PageInfo
+                # `hasNextPage`: Boolean!
+                sig { returns(T::Boolean) }
+                def has_next_page; end
+
+                # `endCursor`: String
+                sig { returns(T.nilable(::String)) }
+                def end_cursor; end
+
+                # `hasPreviousPage`: Boolean!
+                sig { returns(T::Boolean) }
+                def has_previous_page; end
+
+                # `startCursor`: String
+                sig { returns(T.nilable(::String)) }
+                def start_cursor; end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+
+  class GetEntryDataMigrations
+    sig { returns(T.nilable(FragmentClient::Responses::GetEntryDataMigrations::Data)) }
+    def data; end
+
+    sig { returns(T.untyped) }
+    def errors; end
+
+    sig { returns(T::Hash[String, T.untyped]) }
+    def original_hash; end
+
+    class Data
+      # `ledger`: Ledger
+      sig { returns(T.nilable(Ledger)) }
+      def ledger; end
+
+      class Ledger
+        # `ledgerEntryDataMigrations`: LedgerEntryDataMigrationConnection!
+        sig { returns(LedgerEntryDataMigrations) }
+        def ledger_entry_data_migrations; end
+
+        class LedgerEntryDataMigrations
+          # `nodes`: [LedgerEntryDataMigration!]!
+          sig { returns(T::Array[Nodes]) }
+          def nodes; end
+
+          class Nodes
+            # `entryType`: SafeString!
+            sig { returns(::String) }
+            def entry_type; end
+
+            # `typeVersion`: Int!
+            sig { returns(::Integer) }
+            def type_version; end
+
+            # `status`: LedgerDataMigrationStatus!
+            sig { returns(T.untyped) }
+            def status; end
+
+            # `currentMigration`: LedgerDataMigrationHistoryEntry
+            sig { returns(T.nilable(CurrentMigration)) }
+            def current_migration; end
+
+            class CurrentMigration
+              # `schemaVersion`: Int!
+              sig { returns(::Integer) }
+              def schema_version; end
+
+              # `status`: LedgerDataMigrationStatus!
+              sig { returns(T.untyped) }
+              def status; end
+            end
+
+            # `ledgerEntries`: LedgerEntriesConnection!
+            sig { returns(LedgerEntries) }
+            def ledger_entries; end
+
+            class LedgerEntries
+              # `nodes`: [LedgerEntry!]!
+              sig { returns(T::Array[Nodes]) }
+              def nodes; end
+
+              class Nodes
+                # `id`: ID!
+                sig { returns(::String) }
+                def id; end
+
+                # `type`: SafeString
+                sig { returns(T.nilable(::String)) }
+                def type; end
+
+                # `posted`: DateTime!
+                sig { returns(::String) }
+                def posted; end
+
+                # `parameters`: Parameters
+                sig { returns(T.untyped) }
+                def parameters; end
+              end
+
+              # `pageInfo`: PageInfo!
+              sig { returns(PageInfo) }
+              def page_info; end
+
+              class PageInfo
+                # `hasNextPage`: Boolean!
+                sig { returns(T::Boolean) }
+                def has_next_page; end
+
+                # `endCursor`: String
+                sig { returns(T.nilable(::String)) }
+                def end_cursor; end
+
+                # `hasPreviousPage`: Boolean!
+                sig { returns(T::Boolean) }
+                def has_previous_page; end
+
+                # `startCursor`: String
+                sig { returns(T.nilable(::String)) }
+                def start_cursor; end
+              end
+            end
+
+            # `history`: LedgerDataMigrationHistoryConnection!
+            sig { returns(History) }
+            def history; end
+
+            class History
+              # `nodes`: [LedgerDataMigrationHistoryEntry!]!
+              sig { returns(T::Array[Nodes]) }
+              def nodes; end
+
+              class Nodes
+                # `schemaVersion`: Int!
+                sig { returns(::Integer) }
+                def schema_version; end
+
+                # `status`: LedgerDataMigrationStatus!
+                sig { returns(T.untyped) }
+                def status; end
+              end
+
+              # `pageInfo`: PageInfo!
+              sig { returns(PageInfo) }
+              def page_info; end
+
+              class PageInfo
+                # `hasNextPage`: Boolean!
+                sig { returns(T::Boolean) }
+                def has_next_page; end
+
+                # `endCursor`: String
+                sig { returns(T.nilable(::String)) }
+                def end_cursor; end
+
+                # `hasPreviousPage`: Boolean!
+                sig { returns(T::Boolean) }
+                def has_previous_page; end
+
+                # `startCursor`: String
+                sig { returns(T.nilable(::String)) }
+                def start_cursor; end
+              end
+            end
+          end
+
+          # `pageInfo`: PageInfo!
+          sig { returns(PageInfo) }
+          def page_info; end
+
+          class PageInfo
+            # `hasNextPage`: Boolean!
+            sig { returns(T::Boolean) }
+            def has_next_page; end
+
+            # `endCursor`: String
+            sig { returns(T.nilable(::String)) }
+            def end_cursor; end
+
+            # `hasPreviousPage`: Boolean!
+            sig { returns(T::Boolean) }
+            def has_previous_page; end
+
+            # `startCursor`: String
+            sig { returns(T.nilable(::String)) }
+            def start_cursor; end
+          end
+        end
+      end
+    end
+  end
+
+  class GetLedger
+    sig { returns(T.nilable(FragmentClient::Responses::GetLedger::Data)) }
+    def data; end
+
+    sig { returns(T.untyped) }
+    def errors; end
+
+    sig { returns(T::Hash[String, T.untyped]) }
+    def original_hash; end
+
+    class Data
+      # `ledger`: Ledger
+      sig { returns(T.nilable(Ledger)) }
+      def ledger; end
+
+      class Ledger
+        # `id`: ID!
+        sig { returns(::String) }
+        def id; end
+
+        # `ik`: SafeString!
+        sig { returns(::String) }
+        def ik; end
+
+        # `name`: String!
+        sig { returns(::String) }
+        def name; end
+
+        # `created`: DateTime!
+        sig { returns(::String) }
+        def created; end
+
+        # `balanceUTCOffset`: UTCOffset!
+        sig { returns(::String) }
+        def balance_utc_offset; end
+      end
+    end
+  end
+
+  class GetLedgerAccountBalance
+    sig { returns(T.nilable(FragmentClient::Responses::GetLedgerAccountBalance::Data)) }
+    def data; end
+
+    sig { returns(T.untyped) }
+    def errors; end
+
+    sig { returns(T::Hash[String, T.untyped]) }
+    def original_hash; end
+
+    class Data
+      # `ledgerAccount`: LedgerAccount
+      sig { returns(T.nilable(LedgerAccount)) }
+      def ledger_account; end
+
+      class LedgerAccount
+        # `id`: ID!
+        sig { returns(::String) }
+        def id; end
+
+        # `path`: String!
+        sig { returns(::String) }
+        def path; end
+
+        # `balance`: Int96!
+        sig { returns(::String) }
+        def balance; end
+      end
+    end
+  end
+
+  class GetLedgerAccountLines
+    sig { returns(T.nilable(FragmentClient::Responses::GetLedgerAccountLines::Data)) }
+    def data; end
+
+    sig { returns(T.untyped) }
+    def errors; end
+
+    sig { returns(T::Hash[String, T.untyped]) }
+    def original_hash; end
+
+    class Data
+      # `ledgerAccount`: LedgerAccount
+      sig { returns(T.nilable(LedgerAccount)) }
+      def ledger_account; end
+
+      class LedgerAccount
+        # `id`: ID!
+        sig { returns(::String) }
+        def id; end
+
+        # `path`: String!
+        sig { returns(::String) }
+        def path; end
+
+        # `lines`: LedgerLinesConnection!
+        sig { returns(Lines) }
+        def lines; end
+
+        class Lines
+          # `nodes`: [LedgerLine!]!
+          sig { returns(T::Array[Nodes]) }
+          def nodes; end
+
+          class Nodes
+            # `id`: ID!
+            sig { returns(::String) }
+            def id; end
+
+            # `posted`: DateTime
+            sig { returns(T.nilable(::String)) }
+            def posted; end
+
+            # `created`: DateTime
+            sig { returns(T.nilable(::String)) }
+            def created; end
+
+            # `amount`: Int96!
+            sig { returns(::String) }
+            def amount; end
+
+            # `description`: String
+            sig { returns(T.nilable(::String)) }
+            def description; end
+          end
+
+          # `pageInfo`: PageInfo!
+          sig { returns(PageInfo) }
+          def page_info; end
+
+          class PageInfo
+            # `hasNextPage`: Boolean!
+            sig { returns(T::Boolean) }
+            def has_next_page; end
+
+            # `endCursor`: String
+            sig { returns(T.nilable(::String)) }
+            def end_cursor; end
+
+            # `hasPreviousPage`: Boolean!
+            sig { returns(T::Boolean) }
+            def has_previous_page; end
+
+            # `startCursor`: String
+            sig { returns(T.nilable(::String)) }
+            def start_cursor; end
+          end
+        end
+      end
+    end
+  end
+
+  class GetLedgerEntry
+    sig { returns(T.nilable(FragmentClient::Responses::GetLedgerEntry::Data)) }
+    def data; end
+
+    sig { returns(T.untyped) }
+    def errors; end
+
+    sig { returns(T::Hash[String, T.untyped]) }
+    def original_hash; end
+
+    class Data
+      # `ledgerEntry`: LedgerEntry
+      sig { returns(T.nilable(LedgerEntry)) }
+      def ledger_entry; end
+
+      class LedgerEntry
+        # `id`: ID!
+        sig { returns(::String) }
+        def id; end
+
+        # `ik`: String!
+        sig { returns(::String) }
+        def ik; end
+
+        # `posted`: DateTime!
+        sig { returns(::String) }
+        def posted; end
+
+        # `created`: DateTime!
+        sig { returns(::String) }
+        def created; end
+
+        # `description`: String
+        sig { returns(T.nilable(::String)) }
+        def description; end
+
+        # `lines`: LedgerLinesConnection!
+        sig { returns(Lines) }
+        def lines; end
+
+        class Lines
+          # `nodes`: [LedgerLine!]!
+          sig { returns(T::Array[Nodes]) }
+          def nodes; end
+
+          class Nodes
+            # `id`: ID!
+            sig { returns(::String) }
+            def id; end
+
+            # `amount`: Int96!
+            sig { returns(::String) }
+            def amount; end
+
+            # `account`: LedgerAccount!
+            sig { returns(Account) }
+            def account; end
+
+            class Account
+              # `path`: String!
+              sig { returns(::String) }
+              def path; end
+            end
+          end
+        end
+      end
+    end
+  end
+
+  class GetSchema
+    sig { returns(T.nilable(FragmentClient::Responses::GetSchema::Data)) }
+    def data; end
+
+    sig { returns(T.untyped) }
+    def errors; end
+
+    sig { returns(T::Hash[String, T.untyped]) }
+    def original_hash; end
+
+    class Data
+      # `schema`: Schema
+      sig { returns(T.nilable(Schema)) }
+      def schema; end
+
+      class Schema
+        # `key`: SafeString!
+        sig { returns(::String) }
+        def key; end
+
+        # `name`: String!
+        sig { returns(::String) }
+        def name; end
+
+        # `version`: SchemaVersion!
+        sig { returns(Version) }
+        def version; end
+
+        class Version
+          # `created`: DateTime!
+          sig { returns(::String) }
+          def created; end
+
+          # `version`: Int!
+          sig { returns(::Integer) }
+          def version; end
+
+          # `json`: JSON!
+          sig { returns(T.untyped) }
+          def json; end
+        end
+      end
+    end
+  end
+
+  class GetWorkspace
+    sig { returns(T.nilable(FragmentClient::Responses::GetWorkspace::Data)) }
+    def data; end
+
+    sig { returns(T.untyped) }
+    def errors; end
+
+    sig { returns(T::Hash[String, T.untyped]) }
+    def original_hash; end
+
+    class Data
+      # `workspace`: Workspace!
+      sig { returns(Workspace) }
+      def workspace; end
+
+      class Workspace
+        # `id`: String!
+        sig { returns(::String) }
+        def id; end
+
+        # `name`: String!
+        sig { returns(::String) }
+        def name; end
+      end
+    end
+  end
+
+  class ListLedgerAccountBalances
+    sig { returns(T.nilable(FragmentClient::Responses::ListLedgerAccountBalances::Data)) }
+    def data; end
+
+    sig { returns(T.untyped) }
+    def errors; end
+
+    sig { returns(T::Hash[String, T.untyped]) }
+    def original_hash; end
+
+    class Data
+      # `ledger`: Ledger
+      sig { returns(T.nilable(Ledger)) }
+      def ledger; end
+
+      class Ledger
+        # `id`: ID!
+        sig { returns(::String) }
+        def id; end
+
+        # `ik`: SafeString!
+        sig { returns(::String) }
+        def ik; end
+
+        # `name`: String!
+        sig { returns(::String) }
+        def name; end
+
+        # `created`: DateTime!
+        sig { returns(::String) }
+        def created; end
+
+        # `ledgerAccounts`: LedgerAccountsConnection!
+        sig { returns(LedgerAccounts) }
+        def ledger_accounts; end
+
+        class LedgerAccounts
+          # `nodes`: [LedgerAccount!]!
+          sig { returns(T::Array[Nodes]) }
+          def nodes; end
+
+          class Nodes
+            # `id`: ID!
+            sig { returns(::String) }
+            def id; end
+
+            # `path`: String!
+            sig { returns(::String) }
+            def path; end
+
+            # `name`: String
+            sig { returns(T.nilable(::String)) }
+            def name; end
+
+            # `type`: LedgerAccountTypes!
+            sig { returns(T.untyped) }
+            def type; end
+
+            # `created`: DateTime!
+            sig { returns(::String) }
+            def created; end
+
+            # `ownBalance`: Int96!
+            sig { returns(::String) }
+            def own_balance; end
+
+            # `childBalance`: Int96!
+            sig { returns(::String) }
+            def child_balance; end
+
+            # `balance`: Int96!
+            sig { returns(::String) }
+            def balance; end
+          end
+
+          # `pageInfo`: PageInfo!
+          sig { returns(PageInfo) }
+          def page_info; end
+
+          class PageInfo
+            # `hasNextPage`: Boolean!
+            sig { returns(T::Boolean) }
+            def has_next_page; end
+
+            # `endCursor`: String
+            sig { returns(T.nilable(::String)) }
+            def end_cursor; end
+
+            # `hasPreviousPage`: Boolean!
+            sig { returns(T::Boolean) }
+            def has_previous_page; end
+
+            # `startCursor`: String
+            sig { returns(T.nilable(::String)) }
+            def start_cursor; end
+          end
+        end
+      end
+    end
+  end
+
+  class ListLedgerAccounts
+    sig { returns(T.nilable(FragmentClient::Responses::ListLedgerAccounts::Data)) }
+    def data; end
+
+    sig { returns(T.untyped) }
+    def errors; end
+
+    sig { returns(T::Hash[String, T.untyped]) }
+    def original_hash; end
+
+    class Data
+      # `ledger`: Ledger
+      sig { returns(T.nilable(Ledger)) }
+      def ledger; end
+
+      class Ledger
+        # `id`: ID!
+        sig { returns(::String) }
+        def id; end
+
+        # `ik`: SafeString!
+        sig { returns(::String) }
+        def ik; end
+
+        # `name`: String!
+        sig { returns(::String) }
+        def name; end
+
+        # `created`: DateTime!
+        sig { returns(::String) }
+        def created; end
+
+        # `ledgerAccounts`: LedgerAccountsConnection!
+        sig { returns(LedgerAccounts) }
+        def ledger_accounts; end
+
+        class LedgerAccounts
+          # `nodes`: [LedgerAccount!]!
+          sig { returns(T::Array[Nodes]) }
+          def nodes; end
+
+          class Nodes
+            # `id`: ID!
+            sig { returns(::String) }
+            def id; end
+
+            # `path`: String!
+            sig { returns(::String) }
+            def path; end
+
+            # `name`: String
+            sig { returns(T.nilable(::String)) }
+            def name; end
+
+            # `type`: LedgerAccountTypes!
+            sig { returns(T.untyped) }
+            def type; end
+
+            # `created`: DateTime!
+            sig { returns(::String) }
+            def created; end
+          end
+
+          # `pageInfo`: PageInfo!
+          sig { returns(PageInfo) }
+          def page_info; end
+
+          class PageInfo
+            # `hasNextPage`: Boolean!
+            sig { returns(T::Boolean) }
+            def has_next_page; end
+
+            # `endCursor`: String
+            sig { returns(T.nilable(::String)) }
+            def end_cursor; end
+
+            # `hasPreviousPage`: Boolean!
+            sig { returns(T::Boolean) }
+            def has_previous_page; end
+
+            # `startCursor`: String
+            sig { returns(T.nilable(::String)) }
+            def start_cursor; end
+          end
+        end
+      end
+    end
+  end
+
+  class ListLedgerEntries
+    sig { returns(T.nilable(FragmentClient::Responses::ListLedgerEntries::Data)) }
+    def data; end
+
+    sig { returns(T.untyped) }
+    def errors; end
+
+    sig { returns(T::Hash[String, T.untyped]) }
+    def original_hash; end
+
+    class Data
+      # `ledger`: Ledger
+      sig { returns(T.nilable(Ledger)) }
+      def ledger; end
+
+      class Ledger
+        # `ledgerEntries`: LedgerEntriesConnection!
+        sig { returns(LedgerEntries) }
+        def ledger_entries; end
+
+        class LedgerEntries
+          # `nodes`: [LedgerEntry!]!
+          sig { returns(T::Array[Nodes]) }
+          def nodes; end
+
+          class Nodes
+            # `ik`: String!
+            sig { returns(::String) }
+            def ik; end
+
+            # `type`: SafeString
+            sig { returns(T.nilable(::String)) }
+            def type; end
+
+            # `posted`: DateTime!
+            sig { returns(::String) }
+            def posted; end
+
+            # `lines`: LedgerLinesConnection!
+            sig { returns(Lines) }
+            def lines; end
+
+            class Lines
+              # `nodes`: [LedgerLine!]!
+              sig { returns(T::Array[Nodes]) }
+              def nodes; end
+
+              class Nodes
+                # `amount`: Int96!
+                sig { returns(::String) }
+                def amount; end
+
+                # `account`: LedgerAccount!
+                sig { returns(Account) }
+                def account; end
+
+                class Account
+                  # `path`: String!
+                  sig { returns(::String) }
+                  def path; end
+                end
+              end
+            end
+          end
+
+          # `pageInfo`: PageInfo!
+          sig { returns(PageInfo) }
+          def page_info; end
+
+          class PageInfo
+            # `hasNextPage`: Boolean!
+            sig { returns(T::Boolean) }
+            def has_next_page; end
+
+            # `endCursor`: String
+            sig { returns(T.nilable(::String)) }
+            def end_cursor; end
+
+            # `hasPreviousPage`: Boolean!
+            sig { returns(T::Boolean) }
+            def has_previous_page; end
+
+            # `startCursor`: String
+            sig { returns(T.nilable(::String)) }
+            def start_cursor; end
+          end
+        end
+      end
+    end
+  end
+
+  class ListLedgerEntryGroupBalances
+    sig { returns(T.nilable(FragmentClient::Responses::ListLedgerEntryGroupBalances::Data)) }
+    def data; end
+
+    sig { returns(T.untyped) }
+    def errors; end
+
+    sig { returns(T::Hash[String, T.untyped]) }
+    def original_hash; end
+
+    class Data
+      # `ledgerEntryGroup`: LedgerEntryGroup
+      sig { returns(T.nilable(LedgerEntryGroup)) }
+      def ledger_entry_group; end
+
+      class LedgerEntryGroup
+        # `key`: SafeString!
+        sig { returns(::String) }
+        def key; end
+
+        # `value`: SafeString!
+        sig { returns(::String) }
+        def value; end
+
+        # `created`: DateTime
+        sig { returns(T.nilable(::String)) }
+        def created; end
+
+        # `balances`: LedgerEntryGroupBalanceConnection!
+        sig { returns(Balances) }
+        def balances; end
+
+        class Balances
+          # `nodes`: [LedgerEntryGroupBalance!]!
+          sig { returns(T::Array[Nodes]) }
+          def nodes; end
+
+          class Nodes
+            # `account`: LedgerAccount!
+            sig { returns(Account) }
+            def account; end
+
+            class Account
+              # `path`: String!
+              sig { returns(::String) }
+              def path; end
+            end
+
+            # `currency`: Currency!
+            sig { returns(Currency) }
+            def currency; end
+
+            class Currency
+              # `code`: CurrencyCode!
+              sig { returns(T.untyped) }
+              def code; end
+
+              # `customCurrencyId`: SafeString
+              sig { returns(T.nilable(::String)) }
+              def custom_currency_id; end
+            end
+
+            # `ownBalance`: Int96!
+            sig { returns(::String) }
+            def own_balance; end
+          end
+
+          # `pageInfo`: PageInfo!
+          sig { returns(PageInfo) }
+          def page_info; end
+
+          class PageInfo
+            # `hasNextPage`: Boolean!
+            sig { returns(T::Boolean) }
+            def has_next_page; end
+
+            # `endCursor`: String
+            sig { returns(T.nilable(::String)) }
+            def end_cursor; end
+
+            # `hasPreviousPage`: Boolean!
+            sig { returns(T::Boolean) }
+            def has_previous_page; end
+
+            # `startCursor`: String
+            sig { returns(T.nilable(::String)) }
+            def start_cursor; end
+          end
+        end
+      end
+    end
+  end
+
+  class ListMultiCurrencyLedgerAccountBalances
+    sig { returns(T.nilable(FragmentClient::Responses::ListMultiCurrencyLedgerAccountBalances::Data)) }
+    def data; end
+
+    sig { returns(T.untyped) }
+    def errors; end
+
+    sig { returns(T::Hash[String, T.untyped]) }
+    def original_hash; end
+
+    class Data
+      # `ledger`: Ledger
+      sig { returns(T.nilable(Ledger)) }
+      def ledger; end
+
+      class Ledger
+        # `id`: ID!
+        sig { returns(::String) }
+        def id; end
+
+        # `ik`: SafeString!
+        sig { returns(::String) }
+        def ik; end
+
+        # `name`: String!
+        sig { returns(::String) }
+        def name; end
+
+        # `created`: DateTime!
+        sig { returns(::String) }
+        def created; end
+
+        # `ledgerAccounts`: LedgerAccountsConnection!
+        sig { returns(LedgerAccounts) }
+        def ledger_accounts; end
+
+        class LedgerAccounts
+          # `nodes`: [LedgerAccount!]!
+          sig { returns(T::Array[Nodes]) }
+          def nodes; end
+
+          class Nodes
+            # `id`: ID!
+            sig { returns(::String) }
+            def id; end
+
+            # `path`: String!
+            sig { returns(::String) }
+            def path; end
+
+            # `name`: String
+            sig { returns(T.nilable(::String)) }
+            def name; end
+
+            # `type`: LedgerAccountTypes!
+            sig { returns(T.untyped) }
+            def type; end
+
+            # `created`: DateTime!
+            sig { returns(::String) }
+            def created; end
+
+            # `ownBalances`: CurrencyAmountConnection!
+            sig { returns(OwnBalances) }
+            def own_balances; end
+
+            class OwnBalances
+              # `nodes`: [CurrencyAmount!]!
+              sig { returns(T::Array[Nodes]) }
+              def nodes; end
+
+              class Nodes
+                # `currency`: Currency!
+                sig { returns(Currency) }
+                def currency; end
+
+                class Currency
+                  # `code`: CurrencyCode!
+                  sig { returns(T.untyped) }
+                  def code; end
+
+                  # `customCurrencyId`: SafeString
+                  sig { returns(T.nilable(::String)) }
+                  def custom_currency_id; end
+                end
+
+                # `amount`: Int96!
+                sig { returns(::String) }
+                def amount; end
+              end
+            end
+
+            # `childBalances`: CurrencyAmountConnection!
+            sig { returns(ChildBalances) }
+            def child_balances; end
+
+            class ChildBalances
+              # `nodes`: [CurrencyAmount!]!
+              sig { returns(T::Array[Nodes]) }
+              def nodes; end
+
+              class Nodes
+                # `currency`: Currency!
+                sig { returns(Currency) }
+                def currency; end
+
+                class Currency
+                  # `code`: CurrencyCode!
+                  sig { returns(T.untyped) }
+                  def code; end
+
+                  # `customCurrencyId`: SafeString
+                  sig { returns(T.nilable(::String)) }
+                  def custom_currency_id; end
+                end
+
+                # `amount`: Int96!
+                sig { returns(::String) }
+                def amount; end
+              end
+            end
+
+            # `balances`: CurrencyAmountConnection!
+            sig { returns(Balances) }
+            def balances; end
+
+            class Balances
+              # `nodes`: [CurrencyAmount!]!
+              sig { returns(T::Array[Nodes]) }
+              def nodes; end
+
+              class Nodes
+                # `currency`: Currency!
+                sig { returns(Currency) }
+                def currency; end
+
+                class Currency
+                  # `code`: CurrencyCode!
+                  sig { returns(T.untyped) }
+                  def code; end
+
+                  # `customCurrencyId`: SafeString
+                  sig { returns(T.nilable(::String)) }
+                  def custom_currency_id; end
+                end
+
+                # `amount`: Int96!
+                sig { returns(::String) }
+                def amount; end
+              end
+            end
+          end
+
+          # `pageInfo`: PageInfo!
+          sig { returns(PageInfo) }
+          def page_info; end
+
+          class PageInfo
+            # `hasNextPage`: Boolean!
+            sig { returns(T::Boolean) }
+            def has_next_page; end
+
+            # `endCursor`: String
+            sig { returns(T.nilable(::String)) }
+            def end_cursor; end
+
+            # `hasPreviousPage`: Boolean!
+            sig { returns(T::Boolean) }
+            def has_previous_page; end
+
+            # `startCursor`: String
+            sig { returns(T.nilable(::String)) }
+            def start_cursor; end
+          end
+        end
+      end
+    end
+  end
+
+  class MigrateLedgerEntry
+    sig { returns(T.nilable(FragmentClient::Responses::MigrateLedgerEntry::Data)) }
+    def data; end
+
+    sig { returns(T.untyped) }
+    def errors; end
+
+    sig { returns(T::Hash[String, T.untyped]) }
+    def original_hash; end
+
+    class Data
+      # `migrateLedgerEntry`: MigrateLedgerEntryResponse!
+      sig { returns(MigrateLedgerEntry) }
+      def migrate_ledger_entry; end
+
+      class MigrateLedgerEntry
+        sig { returns(::String) }
+        def __typename; end
+
+        # `reversingLedgerEntry`: LedgerEntry!
+        sig { returns(T.nilable(ReversingLedgerEntry)) }
+        def reversing_ledger_entry; end
+
+        class ReversingLedgerEntry
+          # `ik`: String!
+          sig { returns(::String) }
+          def ik; end
+
+          # `id`: ID!
+          sig { returns(::String) }
+          def id; end
+
+          # `created`: DateTime!
+          sig { returns(::String) }
+          def created; end
+
+          # `posted`: DateTime!
+          sig { returns(::String) }
+          def posted; end
+
+          # `type`: SafeString
+          sig { returns(T.nilable(::String)) }
+          def type; end
+
+          # `description`: String
+          sig { returns(T.nilable(::String)) }
+          def description; end
+
+          # `reversedAt`: DateTime
+          sig { returns(T.nilable(::String)) }
+          def reversed_at; end
+
+          # `hidden`: Boolean!
+          sig { returns(T::Boolean) }
+          def hidden; end
+
+          # `lines`: LedgerLinesConnection!
+          sig { returns(Lines) }
+          def lines; end
+
+          class Lines
+            # `nodes`: [LedgerLine!]!
+            sig { returns(T::Array[Nodes]) }
+            def nodes; end
+
+            class Nodes
+              # `id`: ID!
+              sig { returns(::String) }
+              def id; end
+
+              # `amount`: Int96!
+              sig { returns(::String) }
+              def amount; end
+
+              # `account`: LedgerAccount!
+              sig { returns(Account) }
+              def account; end
+
+              class Account
+                # `path`: String!
+                sig { returns(::String) }
+                def path; end
+              end
+            end
+          end
+        end
+
+        # `reversedLedgerEntry`: LedgerEntry!
+        sig { returns(T.nilable(ReversedLedgerEntry)) }
+        def reversed_ledger_entry; end
+
+        class ReversedLedgerEntry
+          # `ik`: String!
+          sig { returns(::String) }
+          def ik; end
+
+          # `id`: ID!
+          sig { returns(::String) }
+          def id; end
+
+          # `created`: DateTime!
+          sig { returns(::String) }
+          def created; end
+
+          # `posted`: DateTime!
+          sig { returns(::String) }
+          def posted; end
+
+          # `type`: SafeString
+          sig { returns(T.nilable(::String)) }
+          def type; end
+
+          # `description`: String
+          sig { returns(T.nilable(::String)) }
+          def description; end
+
+          # `reversedAt`: DateTime
+          sig { returns(T.nilable(::String)) }
+          def reversed_at; end
+
+          # `hidden`: Boolean!
+          sig { returns(T::Boolean) }
+          def hidden; end
+
+          # `lines`: LedgerLinesConnection!
+          sig { returns(Lines) }
+          def lines; end
+
+          class Lines
+            # `nodes`: [LedgerLine!]!
+            sig { returns(T::Array[Nodes]) }
+            def nodes; end
+
+            class Nodes
+              # `id`: ID!
+              sig { returns(::String) }
+              def id; end
+
+              # `amount`: Int96!
+              sig { returns(::String) }
+              def amount; end
+
+              # `account`: LedgerAccount!
+              sig { returns(Account) }
+              def account; end
+
+              class Account
+                # `path`: String!
+                sig { returns(::String) }
+                def path; end
+              end
+            end
+          end
+        end
+
+        # `newLedgerEntry`: LedgerEntry!
+        sig { returns(T.nilable(NewLedgerEntry)) }
+        def new_ledger_entry; end
+
+        class NewLedgerEntry
+          # `ik`: String!
+          sig { returns(::String) }
+          def ik; end
+
+          # `id`: ID!
+          sig { returns(::String) }
+          def id; end
+
+          # `created`: DateTime!
+          sig { returns(::String) }
+          def created; end
+
+          # `posted`: DateTime!
+          sig { returns(::String) }
+          def posted; end
+
+          # `type`: SafeString
+          sig { returns(T.nilable(::String)) }
+          def type; end
+
+          # `description`: String
+          sig { returns(T.nilable(::String)) }
+          def description; end
+
+          # `reversedAt`: DateTime
+          sig { returns(T.nilable(::String)) }
+          def reversed_at; end
+
+          # `hidden`: Boolean!
+          sig { returns(T::Boolean) }
+          def hidden; end
+
+          # `lines`: LedgerLinesConnection!
+          sig { returns(Lines) }
+          def lines; end
+
+          class Lines
+            # `nodes`: [LedgerLine!]!
+            sig { returns(T::Array[Nodes]) }
+            def nodes; end
+
+            class Nodes
+              # `id`: ID!
+              sig { returns(::String) }
+              def id; end
+
+              # `amount`: Int96!
+              sig { returns(::String) }
+              def amount; end
+
+              # `account`: LedgerAccount!
+              sig { returns(Account) }
+              def account; end
+
+              class Account
+                # `path`: String!
+                sig { returns(::String) }
+                def path; end
+              end
+            end
+          end
+        end
+
+        # `isIkReplay`: Boolean!
+        sig { returns(T.nilable(T::Boolean)) }
+        def is_ik_replay; end
+
+        # `code`: String!
+        sig { returns(T.nilable(::String)) }
+        def code; end
+
+        # `message`: String!
+        sig { returns(T.nilable(::String)) }
+        def message; end
+
+        # `retryable`: Boolean!
+        sig { returns(T.nilable(T::Boolean)) }
+        def retryable; end
+      end
+    end
+  end
+
+  class ReconcileTx
+    sig { returns(T.nilable(FragmentClient::Responses::ReconcileTx::Data)) }
+    def data; end
+
+    sig { returns(T.untyped) }
+    def errors; end
+
+    sig { returns(T::Hash[String, T.untyped]) }
+    def original_hash; end
+
+    class Data
+      # `reconcileTx`: ReconcileTxResponse!
+      sig { returns(ReconcileTx) }
+      def reconcile_tx; end
+
+      class ReconcileTx
+        sig { returns(::String) }
+        def __typename; end
+
+        # `entry`: LedgerEntry!
+        sig { returns(T.nilable(Entry)) }
+        def entry; end
+
+        class Entry
+          # `id`: ID!
+          sig { returns(::String) }
+          def id; end
+
+          # `ik`: String!
+          sig { returns(::String) }
+          def ik; end
+
+          # `date`: Date!
+          sig { returns(::String) }
+          def date; end
+
+          # `posted`: DateTime!
+          sig { returns(::String) }
+          def posted; end
+
+          # `created`: DateTime!
+          sig { returns(::String) }
+          def created; end
+
+          # `description`: String
+          sig { returns(T.nilable(::String)) }
+          def description; end
+        end
+
+        # `lines`: [LedgerLine!]!
+        sig { returns(T.nilable(T::Array[Lines])) }
+        def lines; end
+
+        class Lines
+          # `id`: ID!
+          sig { returns(::String) }
+          def id; end
+
+          # `amount`: Int96!
+          sig { returns(::String) }
+          def amount; end
+
+          # `account`: LedgerAccount!
+          sig { returns(Account) }
+          def account; end
+
+          class Account
+            # `path`: String!
+            sig { returns(::String) }
+            def path; end
+          end
+
+          # `externalTxId`: String
+          sig { returns(T.nilable(::String)) }
+          def external_tx_id; end
+        end
+
+        # `code`: String!
+        sig { returns(T.nilable(::String)) }
+        def code; end
+
+        # `message`: String!
+        sig { returns(T.nilable(::String)) }
+        def message; end
+
+        # `retryable`: Boolean!
+        sig { returns(T.nilable(T::Boolean)) }
+        def retryable; end
+      end
+    end
+  end
+
+  class ReconcileTxRuntime
+    sig { returns(T.nilable(FragmentClient::Responses::ReconcileTxRuntime::Data)) }
+    def data; end
+
+    sig { returns(T.untyped) }
+    def errors; end
+
+    sig { returns(T::Hash[String, T.untyped]) }
+    def original_hash; end
+
+    class Data
+      # `reconcileTx`: ReconcileTxResponse!
+      sig { returns(ReconcileTx) }
+      def reconcile_tx; end
+
+      class ReconcileTx
+        sig { returns(::String) }
+        def __typename; end
+
+        # `entry`: LedgerEntry!
+        sig { returns(T.nilable(Entry)) }
+        def entry; end
+
+        class Entry
+          # `id`: ID!
+          sig { returns(::String) }
+          def id; end
+
+          # `ik`: String!
+          sig { returns(::String) }
+          def ik; end
+
+          # `date`: Date!
+          sig { returns(::String) }
+          def date; end
+
+          # `posted`: DateTime!
+          sig { returns(::String) }
+          def posted; end
+
+          # `created`: DateTime!
+          sig { returns(::String) }
+          def created; end
+
+          # `description`: String
+          sig { returns(T.nilable(::String)) }
+          def description; end
+        end
+
+        # `lines`: [LedgerLine!]!
+        sig { returns(T.nilable(T::Array[Lines])) }
+        def lines; end
+
+        class Lines
+          # `id`: ID!
+          sig { returns(::String) }
+          def id; end
+
+          # `amount`: Int96!
+          sig { returns(::String) }
+          def amount; end
+
+          # `account`: LedgerAccount!
+          sig { returns(Account) }
+          def account; end
+
+          class Account
+            # `path`: String!
+            sig { returns(::String) }
+            def path; end
+          end
+
+          # `externalTxId`: String
+          sig { returns(T.nilable(::String)) }
+          def external_tx_id; end
+        end
+
+        # `code`: String!
+        sig { returns(T.nilable(::String)) }
+        def code; end
+
+        # `message`: String!
+        sig { returns(T.nilable(::String)) }
+        def message; end
+
+        # `retryable`: Boolean!
+        sig { returns(T.nilable(T::Boolean)) }
+        def retryable; end
+      end
+    end
+  end
+
+  class ReverseLedgerEntry
+    sig { returns(T.nilable(FragmentClient::Responses::ReverseLedgerEntry::Data)) }
+    def data; end
+
+    sig { returns(T.untyped) }
+    def errors; end
+
+    sig { returns(T::Hash[String, T.untyped]) }
+    def original_hash; end
+
+    class Data
+      # `reverseLedgerEntry`: ReverseLedgerEntryResponse!
+      sig { returns(ReverseLedgerEntry) }
+      def reverse_ledger_entry; end
+
+      class ReverseLedgerEntry
+        sig { returns(::String) }
+        def __typename; end
+
+        # `reversingLedgerEntry`: LedgerEntry!
+        sig { returns(T.nilable(ReversingLedgerEntry)) }
+        def reversing_ledger_entry; end
+
+        class ReversingLedgerEntry
+          # `ik`: String!
+          sig { returns(::String) }
+          def ik; end
+
+          # `id`: ID!
+          sig { returns(::String) }
+          def id; end
+
+          # `created`: DateTime!
+          sig { returns(::String) }
+          def created; end
+
+          # `posted`: DateTime!
+          sig { returns(::String) }
+          def posted; end
+
+          # `type`: SafeString
+          sig { returns(T.nilable(::String)) }
+          def type; end
+
+          # `description`: String
+          sig { returns(T.nilable(::String)) }
+          def description; end
+
+          # `hidden`: Boolean!
+          sig { returns(T::Boolean) }
+          def hidden; end
+
+          # `lines`: LedgerLinesConnection!
+          sig { returns(Lines) }
+          def lines; end
+
+          class Lines
+            # `nodes`: [LedgerLine!]!
+            sig { returns(T::Array[Nodes]) }
+            def nodes; end
+
+            class Nodes
+              # `id`: ID!
+              sig { returns(::String) }
+              def id; end
+
+              # `amount`: Int96!
+              sig { returns(::String) }
+              def amount; end
+
+              # `account`: LedgerAccount!
+              sig { returns(Account) }
+              def account; end
+
+              class Account
+                # `path`: String!
+                sig { returns(::String) }
+                def path; end
+              end
+            end
+          end
+        end
+
+        # `reversedLedgerEntry`: LedgerEntry!
+        sig { returns(T.nilable(ReversedLedgerEntry)) }
+        def reversed_ledger_entry; end
+
+        class ReversedLedgerEntry
+          # `ik`: String!
+          sig { returns(::String) }
+          def ik; end
+
+          # `id`: ID!
+          sig { returns(::String) }
+          def id; end
+
+          # `created`: DateTime!
+          sig { returns(::String) }
+          def created; end
+
+          # `posted`: DateTime!
+          sig { returns(::String) }
+          def posted; end
+
+          # `type`: SafeString
+          sig { returns(T.nilable(::String)) }
+          def type; end
+
+          # `description`: String
+          sig { returns(T.nilable(::String)) }
+          def description; end
+
+          # `hidden`: Boolean!
+          sig { returns(T::Boolean) }
+          def hidden; end
+
+          # `lines`: LedgerLinesConnection!
+          sig { returns(Lines) }
+          def lines; end
+
+          class Lines
+            # `nodes`: [LedgerLine!]!
+            sig { returns(T::Array[Nodes]) }
+            def nodes; end
+
+            class Nodes
+              # `id`: ID!
+              sig { returns(::String) }
+              def id; end
+
+              # `amount`: Int96!
+              sig { returns(::String) }
+              def amount; end
+
+              # `account`: LedgerAccount!
+              sig { returns(Account) }
+              def account; end
+
+              class Account
+                # `path`: String!
+                sig { returns(::String) }
+                def path; end
+              end
+            end
+          end
+        end
+
+        # `isIkReplay`: Boolean!
+        sig { returns(T.nilable(T::Boolean)) }
+        def is_ik_replay; end
+
+        # `code`: String!
+        sig { returns(T.nilable(::String)) }
+        def code; end
+
+        # `message`: String!
+        sig { returns(T.nilable(::String)) }
+        def message; end
+
+        # `retryable`: Boolean!
+        sig { returns(T.nilable(T::Boolean)) }
+        def retryable; end
+      end
+    end
+  end
+
+  class StoreSchema
+    sig { returns(T.nilable(FragmentClient::Responses::StoreSchema::Data)) }
+    def data; end
+
+    sig { returns(T.untyped) }
+    def errors; end
+
+    sig { returns(T::Hash[String, T.untyped]) }
+    def original_hash; end
+
+    class Data
+      # `storeSchema`: StoreSchemaResponse!
+      sig { returns(StoreSchema) }
+      def store_schema; end
+
+      class StoreSchema
+        sig { returns(::String) }
+        def __typename; end
+
+        # `schema`: Schema!
+        sig { returns(T.nilable(Schema)) }
+        def schema; end
+
+        class Schema
+          # `key`: SafeString!
+          sig { returns(::String) }
+          def key; end
+
+          # `name`: String!
+          sig { returns(::String) }
+          def name; end
+
+          # `version`: SchemaVersion!
+          sig { returns(Version) }
+          def version; end
+
+          class Version
+            # `created`: DateTime!
+            sig { returns(::String) }
+            def created; end
+
+            # `version`: Int!
+            sig { returns(::Integer) }
+            def version; end
+          end
+        end
+
+        # `code`: String!
+        sig { returns(T.nilable(::String)) }
+        def code; end
+
+        # `message`: String!
+        sig { returns(T.nilable(::String)) }
+        def message; end
+
+        # `retryable`: Boolean!
+        sig { returns(T.nilable(T::Boolean)) }
+        def retryable; end
+      end
+    end
+  end
+
+  class SyncCustomAccounts
+    sig { returns(T.nilable(FragmentClient::Responses::SyncCustomAccounts::Data)) }
+    def data; end
+
+    sig { returns(T.untyped) }
+    def errors; end
+
+    sig { returns(T::Hash[String, T.untyped]) }
+    def original_hash; end
+
+    class Data
+      # `syncCustomAccounts`: SyncCustomAccountsResponse!
+      sig { returns(SyncCustomAccounts) }
+      def sync_custom_accounts; end
+
+      class SyncCustomAccounts
+        sig { returns(::String) }
+        def __typename; end
+
+        # `accounts`: [ExternalAccount!]!
+        sig { returns(T.nilable(T::Array[Accounts])) }
+        def accounts; end
+
+        class Accounts
+          # `id`: ID!
+          sig { returns(::String) }
+          def id; end
+
+          # `externalId`: ID!
+          sig { returns(::String) }
+          def external_id; end
+
+          # `name`: String!
+          sig { returns(::String) }
+          def name; end
+
+          # `currency`: Currency
+          sig { returns(T.nilable(Currency)) }
+          def currency; end
+
+          class Currency
+            # `code`: CurrencyCode!
+            sig { returns(T.untyped) }
+            def code; end
+
+            # `customCurrencyId`: SafeString
+            sig { returns(T.nilable(::String)) }
+            def custom_currency_id; end
+          end
+        end
+
+        # `code`: String!
+        sig { returns(T.nilable(::String)) }
+        def code; end
+
+        # `message`: String!
+        sig { returns(T.nilable(::String)) }
+        def message; end
+
+        # `retryable`: Boolean!
+        sig { returns(T.nilable(T::Boolean)) }
+        def retryable; end
+      end
+    end
+  end
+
+  class SyncCustomTxs
+    sig { returns(T.nilable(FragmentClient::Responses::SyncCustomTxs::Data)) }
+    def data; end
+
+    sig { returns(T.untyped) }
+    def errors; end
+
+    sig { returns(T::Hash[String, T.untyped]) }
+    def original_hash; end
+
+    class Data
+      # `syncCustomTxs`: SyncCustomTxsResponse!
+      sig { returns(SyncCustomTxs) }
+      def sync_custom_txs; end
+
+      class SyncCustomTxs
+        sig { returns(::String) }
+        def __typename; end
+
+        # `txs`: [Tx!]!
+        sig { returns(T.nilable(T::Array[Txs])) }
+        def txs; end
+
+        class Txs
+          sig { returns(::String) }
+          def __typename; end
+
+          # `linkId`: ID!
+          sig { returns(::String) }
+          def link_id; end
+
+          # `id`: ID!
+          sig { returns(::String) }
+          def id; end
+
+          # `externalId`: ID!
+          sig { returns(::String) }
+          def external_id; end
+
+          # `externalAccountId`: ID!
+          sig { returns(::String) }
+          def external_account_id; end
+
+          # `amount`: Int96!
+          sig { returns(::String) }
+          def amount; end
+
+          # `description`: String!
+          sig { returns(::String) }
+          def description; end
+
+          # `posted`: DateTime!
+          sig { returns(::String) }
+          def posted; end
+        end
+
+        # `code`: String!
+        sig { returns(T.nilable(::String)) }
+        def code; end
+
+        # `message`: String!
+        sig { returns(T.nilable(::String)) }
+        def message; end
+
+        # `retryable`: Boolean!
+        sig { returns(T.nilable(T::Boolean)) }
+        def retryable; end
+      end
+    end
+  end
+
+  class UpdateLedger
+    sig { returns(T.nilable(FragmentClient::Responses::UpdateLedger::Data)) }
+    def data; end
+
+    sig { returns(T.untyped) }
+    def errors; end
+
+    sig { returns(T::Hash[String, T.untyped]) }
+    def original_hash; end
+
+    class Data
+      # `updateLedger`: UpdateLedgerResponse!
+      sig { returns(UpdateLedger) }
+      def update_ledger; end
+
+      class UpdateLedger
+        sig { returns(::String) }
+        def __typename; end
+
+        # `ledger`: Ledger!
+        sig { returns(T.nilable(Ledger)) }
+        def ledger; end
+
+        class Ledger
+          # `id`: ID!
+          sig { returns(::String) }
+          def id; end
+
+          # `ik`: SafeString!
+          sig { returns(::String) }
+          def ik; end
+
+          # `name`: String!
+          sig { returns(::String) }
+          def name; end
+        end
+
+        # `code`: String!
+        sig { returns(T.nilable(::String)) }
+        def code; end
+
+        # `message`: String!
+        sig { returns(T.nilable(::String)) }
+        def message; end
+
+        # `retryable`: Boolean!
+        sig { returns(T.nilable(T::Boolean)) }
+        def retryable; end
+      end
+    end
+  end
+
+  class UpdateLedgerEntry
+    sig { returns(T.nilable(FragmentClient::Responses::UpdateLedgerEntry::Data)) }
+    def data; end
+
+    sig { returns(T.untyped) }
+    def errors; end
+
+    sig { returns(T::Hash[String, T.untyped]) }
+    def original_hash; end
+
+    class Data
+      # `updateLedgerEntry`: UpdateLedgerEntryResponse!
+      sig { returns(UpdateLedgerEntry) }
+      def update_ledger_entry; end
+
+      class UpdateLedgerEntry
+        sig { returns(::String) }
+        def __typename; end
+
+        # `entry`: LedgerEntry!
+        sig { returns(T.nilable(Entry)) }
+        def entry; end
+
+        class Entry
+          # `id`: ID!
+          sig { returns(::String) }
+          def id; end
+
+          # `ik`: String!
+          sig { returns(::String) }
+          def ik; end
+
+          # `posted`: DateTime!
+          sig { returns(::String) }
+          def posted; end
+
+          # `created`: DateTime!
+          sig { returns(::String) }
+          def created; end
+
+          # `description`: String
+          sig { returns(T.nilable(::String)) }
+          def description; end
+
+          # `lines`: LedgerLinesConnection!
+          sig { returns(Lines) }
+          def lines; end
+
+          class Lines
+            # `nodes`: [LedgerLine!]!
+            sig { returns(T::Array[Nodes]) }
+            def nodes; end
+
+            class Nodes
+              # `id`: ID!
+              sig { returns(::String) }
+              def id; end
+
+              # `amount`: Int96!
+              sig { returns(::String) }
+              def amount; end
+
+              # `account`: LedgerAccount!
+              sig { returns(Account) }
+              def account; end
+
+              class Account
+                # `path`: String!
+                sig { returns(::String) }
+                def path; end
+              end
+            end
+          end
+
+          # `groups`: [LedgerEntryGroup!]!
+          sig { returns(T::Array[Groups]) }
+          def groups; end
+
+          class Groups
+            # `key`: SafeString!
+            sig { returns(::String) }
+            def key; end
+
+            # `value`: SafeString!
+            sig { returns(::String) }
+            def value; end
+          end
+
+          # `tags`: [LedgerEntryTag!]!
+          sig { returns(T::Array[Tags]) }
+          def tags; end
+
+          class Tags
+            # `key`: SafeString!
+            sig { returns(::String) }
+            def key; end
+
+            # `value`: SafeString!
+            sig { returns(::String) }
+            def value; end
+          end
+        end
+
+        # `code`: String!
+        sig { returns(T.nilable(::String)) }
+        def code; end
+
+        # `message`: String!
+        sig { returns(T.nilable(::String)) }
+        def message; end
+
+        # `retryable`: Boolean!
+        sig { returns(T.nilable(T::Boolean)) }
+        def retryable; end
+      end
+    end
+  end
 end
 
 class FragmentClient::Entries::AuthCaptureV1 < ::FragmentClient::TypedLedgerEntry

--- a/sorbet/type_checks/response_types.rb
+++ b/sorbet/type_checks/response_types.rb
@@ -1,0 +1,35 @@
+# typed: strict
+# frozen_string_literal: true
+
+# Static assertions about the response objects. Never loaded at runtime.
+#
+# The runtime objects are anonymous classes serving fields through
+# `method_missing`, so these types come from the selection set and the Schema.
+# graphql-client enforces the same selection set at runtime, which is what keeps
+# the two in agreement.
+module FragmentResponseChecks
+  extend T::Sig
+
+  sig { params(client: FragmentClient).returns(T.nilable(String)) }
+  def self.scalars(client)
+    ledger = client.get_ledger({ ik: 'your-ledger-ik' }).data&.ledger
+    # `id` and `name` are non-null in the Schema, so they need no narrowing once
+    # the nilable chain above is.
+    ledger && "#{ledger.id} #{ledger.name} #{ledger.balance_utc_offset}"
+  end
+
+  sig { params(client: FragmentClient).returns(T.nilable(Integer)) }
+  def self.nested(client)
+    client.get_ledger_entry({ ik: 'k', ledgerIk: 'l' }).data&.ledger_entry&.lines&.nodes&.length
+  end
+
+  # A union response: every branch's fields are nilable, because graphql-client
+  # returns one object whatever the `__typename`.
+  sig { params(client: FragmentClient).returns(T.nilable(String)) }
+  def self.union(client)
+    result = client.create_ledger({ ik: 'x', ledger: { name: 'n' }, schemaKey: 'k' }).data&.create_ledger
+    return nil if result.nil?
+
+    result.__typename == 'CreateLedgerResult' ? result.ledger&.name : result.message
+  end
+end

--- a/test/snapshot_test.rb
+++ b/test/snapshot_test.rb
@@ -7,6 +7,7 @@ require 'minitest/autorun'
 require 'tapioca/internal'
 require 'tapioca/dsl/compilers/fragment_typed_entries'
 require 'tapioca/dsl/compilers/fragment_query_methods'
+require 'tapioca/dsl/compilers/fragment_response_types'
 
 # Snapshot of the RBI the Tapioca DSL compiler generates.
 #
@@ -31,7 +32,8 @@ require 'tapioca/dsl/compilers/fragment_query_methods'
 # Regenerate with `bundle exec rake snapshot` and read the diff.
 class SnapshotTest < Minitest::Test
   COMPILERS = [Tapioca::Dsl::Compilers::FragmentTypedEntries,
-               Tapioca::Dsl::Compilers::FragmentQueryMethods].freeze
+               Tapioca::Dsl::Compilers::FragmentQueryMethods,
+               Tapioca::Dsl::Compilers::FragmentResponseTypes].freeze
 
   FIXTURE = File.expand_path('fixtures/snapshot_entries.graphql', __dir__)
   SNAPSHOT = File.expand_path('../sorbet/snapshots/typed_entries.rbi', __dir__)

--- a/test/type_check_test.rb
+++ b/test/type_check_test.rb
@@ -62,6 +62,16 @@ class TypeCheckTest < Minitest::Test
       "FragmentClient.new('id', 'secret').create_ledger('not a hash')",
       'for argument `variables`'
     ],
+    # The field is in the Schema but not in `GetLedger`'s selection set, so
+    # graphql-client refuses it at runtime; now Sorbet refuses it first.
+    'a response field the operation did not select' => [
+      "FragmentClient.new('id', 'secret').get_ledger({ ik: 'k' }).data&.ledger&.schema",
+      'Method `schema` does not exist on `FragmentClient::Responses::GetLedger::Data::Ledger`'
+    ],
+    'a response field read at the wrong type' => [
+      "FragmentClient.new('id', 'secret').get_ledger({ ik: 'k' }).data&.ledger&.name&.no_such",
+      'Method `no_such` does not exist on `String`'
+    ],
     'a batch method given something other than an array' => [
       "FragmentClient.new('id', 'secret').add_ledger_entries(entries: 'not an array')",
       'for argument `entries`'


### PR DESCRIPTION
> Written by Claude, running in Steven's session — these are Claude's words and judgements, not Steven's.

Stacked on #63. The last untyped surface — and the place a caller spends most of their time.

## Why these types can be trusted

graphql-client builds response objects at runtime from anonymous classes whose fields are served by `method_missing`. Their class name is `#<Module:0x...>::Ledger` and `instance_methods` lists only `method_missing`, `to_h` and friends — there is nothing to reflect on. So the shape is derived from each operation's selection set and the pinned Schema: the same two inputs graphql-client itself uses.

That is what makes this sound rather than a guess. **graphql-client already refuses at runtime to read a field the operation did not select** (`ImplicitlyFetchedFieldError`), so a type derived from the selection set cannot promise more than the runtime allows. They agree by construction:

```ruby
client.get_ledger({ ik: 'k' }).data&.ledger&.name    # ::String
client.get_ledger({ ik: 'k' }).data&.ledger&.schema  # rejected — GetLedger doesn't select it
```

The second line is exactly the error graphql-client raises at runtime, now caught before it can happen. I found that the hard way earlier in this stack: I mistook that guard for a bug in the SDK and reported it as one. It is not — and this PR turns it into a compile-time error.

## Details

- **Nullability comes from the Schema.** A non-null field like `id: ID!` needs no narrowing; a nullable one does.
- **Lists carry element nullability.** `[Ledger!]!` becomes `T::Array[X]`; `[Ledger]` becomes `T::Array[T.nilable(X)]`.
- **Scalars** go through the same `GraphqlSorbetTypes` helper #62 extracted — the first real evidence that extraction was worth doing.
- **Unions** — every mutation response is one — contribute every branch's fields, each nilable, because graphql-client returns a single object whatever the `__typename` and only the matching branch carries values. Modelling them as `T.any` of distinct classes would be untrue to the runtime.

**The union limitation is worth knowing:** a caller narrows on `__typename` and then unwraps nilables, and Sorbet cannot link those two steps. Field names and types are checked; "these fields arrive together" is not.

## Not semver-visible

Against published 2.0.0 these methods do not exist as far as Sorbet is concerned — they report `Method 'get_ledger' does not exist`. Going straight to a typed response is additive. **Doing it in this stack rather than after 2.1.0 is what keeps it that way:** narrowing a shipped `T.untyped` return would not be. RBI files are inert at runtime, so nothing changes for anyone not running Sorbet.

## Verification

`sorbet/type_checks/response_types.rb` holds positive cases including a union narrowed on `__typename`; `test/type_check_test.rb` adds two negatives (an unselected field, and a field read at the wrong type). The snapshot grows to 3,269 lines — it is the generated artifact, and CI diffs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
