### PR TITLE
Make the batch method and the payloads read like ordinary Ruby

### DIFF
--- a/docs/spec-conformance.md
+++ b/docs/spec-conformance.md
@@ -78,7 +78,7 @@ on every optional field.
 | 3.4 | Baseline equivalence | Parsed-JSON equality against `expected.json` | all six fixtures |
 | 3.4 | Strict equivalence (optional) | **Met.** See below | byte comparison in `conformance_test.rb`; `test_key_order_is_canonical` |
 | 3.5 | Raw and typed in one batch | `to_entry_inputs` passes non-payloads through untouched | `test_typed_and_raw_entries_may_be_mixed_and_keep_their_order` |
-| 3.6 | Everything accepted serialises | `add_ledger_entries` takes `T::Array[T.untyped]` and converts every payload before the encoder | `add_ledger_entries_test.rb` asserts on the request body, not on the hash |
+| 3.6 | Everything accepted serialises | `add_ledger_entries` converts every payload in `entries` before the encoder; the sig rejects a non-array | `add_ledger_entries_test.rb` asserts on the request body, not on the hash |
 | 4 | Atomicity, per-entry IK replay, narrowing, per-entry errors | The `AddLedgerEntries` operation selects `results`, and `errors { ik ... }` on `AddLedgerEntriesError` | `test_results_are_returned_per_entry_with_ik_replay`; `test_per_entry_errors_are_surfaced_with_the_ik_that_identifies_them` |
 
 ---

--- a/lib/fragment_client.rb
+++ b/lib/fragment_client.rb
@@ -222,11 +222,21 @@ class FragmentClient
   # The response is a union. Narrow on `__typename` before reading `results`, and
   # read `errors` on `AddLedgerEntriesError` for the per-entry failures, each
   # carrying the `ik` of the entry that failed (spec 4).
-  sig { params(entries: T::Array[T.untyped]).returns(T.untyped) }
-  def add_ledger_entries(entries:)
+  # Takes the operation's variables, like every other operation method, so
+  # `add_ledger_entries(entries: [...])` and `add_ledger_entries({ entries: [...] })`
+  # both work. Typed payloads in `entries` are converted; anything else passes
+  # through.
+  #
+  # The return type stays untyped here, unlike the generated methods: a signature in
+  # shipped source cannot name `FragmentClient::Responses::AddLedgerEntries`, which
+  # does not exist until a consumer runs `tapioca dsl`.
+  sig { params(variables: T::Hash[T.untyped, T.untyped]).returns(T.untyped) }
+  def add_ledger_entries(variables)
     query(
       FragmentGraphQl.operation(:AddLedgerEntries),
-      { entries: TypedEntries.to_entry_inputs(entries) }
+      variables.to_h do |name, value|
+        [name, name.to_s == 'entries' ? TypedEntries.to_entry_inputs(value) : value]
+      end
     )
   end
 

--- a/lib/fragment_client/typed_ledger_entry.rb
+++ b/lib/fragment_client/typed_ledger_entry.rb
@@ -184,6 +184,8 @@ class FragmentClient
       { 'entry' => entry_input, 'ik' => @ik }
     end
 
+    alias to_h to_entry_input
+
     # The `parameters` payload, keyed by verbatim Schema parameter name -- so an
     # escaped parameter still travels under its own key (spec 2.5, 3.3).
     sig { returns(T::Hash[String, T.untyped]) }

--- a/test/add_ledger_entries_test.rb
+++ b/test/add_ledger_entries_test.rb
@@ -57,6 +57,26 @@ class AddLedgerEntriesTest < Minitest::Test
     assert_equal 'auth_capture', FragmentClient::Entries::AuthCaptureV1.entry_type
   end
 
+  def test_the_variables_hash_form_works_like_every_other_operation_method
+    # Someone reading queries.graphql writes the variables hash directly, and the
+    # keyword form is the same call in Ruby. Both must reach the same request.
+    entry = { ik: 'raw-1', entry: { ledger: { ik: 'prod' }, type: 't' } }
+    positional = capture_request(extra_queries: false) { |c| c.add_ledger_entries({ entries: [entry] }) }
+    keyword = capture_request(extra_queries: false) { |c| c.add_ledger_entries(entries: [entry]) }
+
+    assert_equal positional.dig('variables', 'entries'), keyword.dig('variables', 'entries')
+    assert_equal 'raw-1', keyword.dig('variables', 'entries', 0, 'ik')
+  end
+
+  def test_a_payload_converts_to_a_hash_under_either_name
+    FragmentClient::TypedEntries.load_string(OPERATIONS)
+    entry = FragmentClient::Entries::AuthCaptureV1.new(
+      ik: 'ik-1', ledger_ik: 'prod', user_id: 'u', capture_amount: '1'
+    )
+
+    assert_equal entry.to_entry_input, entry.to_h
+  end
+
   def test_raw_entries_work_without_loading_any_typed_payloads
     # The batch method is not conditional on the typed-payload machinery: a client
     # constructed with no extra queries still posts a batch of plain hashes, which

--- a/test/type_check_test.rb
+++ b/test/type_check_test.rb
@@ -72,9 +72,12 @@ class TypeCheckTest < Minitest::Test
       "FragmentClient.new('id', 'secret').get_ledger({ ik: 'k' }).data&.ledger&.name&.no_such",
       'Method `no_such` does not exist on `String`'
     ],
-    'a batch method given something other than an array' => [
-      "FragmentClient.new('id', 'secret').add_ledger_entries(entries: 'not an array')",
-      'for argument `entries`'
+    # `add_ledger_entries` takes a variables hash like every other operation method,
+    # so the `entries` value is checked at runtime by its sig rather than statically.
+    # What is still rejected here is not passing a variables hash at all.
+    'a batch method given something other than a variables hash' => [
+      "FragmentClient.new('id', 'secret').add_ledger_entries('nope')",
+      'for argument `variables`'
     ]
   }.freeze
 


### PR DESCRIPTION
> Written by Claude, running in Steven's session — these are Claude's words and judgements, not Steven's.

Stacked on #64. Two places where I had reached for something other than the obvious Ruby, found by auditing the public surface against what this SDK already does.

## The batch method now matches its siblings

`add_ledger_entries` took a required `entries:` keyword. All thirty-three generated operation methods take the operation's variables hash positionally:

```ruby
client.create_ledger({})
client.buzz(ledgerAccount: { path: 'assets' })
```

It now does the same, so nobody has to remember that one method is special, and `add_ledger_entries({ entries: [...] })` works for anyone copying the shape out of `queries.graphql`. **Existing call sites are unchanged** — in Ruby, `add_ledger_entries(entries: [...])` is the same call either way.

**This costs one static check, and I want that on the record.** `entries` now sits inside an untyped variables hash, as every other operation's variables do, so a non-array is caught by the sig at runtime rather than by `srb tc`. `test/type_check_test.rb` says so explicitly rather than quietly dropping the case. The typed payloads' own construction is unaffected, which is where the checking earns its keep. If you would rather keep the static check and accept the inconsistency, reverting this half is a small change.

## `to_h`

Now an alias for `to_entry_input`. For an object whose whole purpose is to become a request body, `to_h` is what a Ruby caller reaches for. I rejected it earlier reasoning that returning a nested transform rather than the object's own attributes would surprise people; that was the wrong call. The longer name stays for when being explicit helps.

## Left alone, on reflection

- **`TypedEntries.load` shadows `Kernel#load`** — which is exactly what `YAML.load`, `JSON.load` and `Marshal.load` do. Keeping it, now for a positive reason rather than a tolerated one.
- **`set?(:posted)` rather than a `posted?` predicate** — in this ecosystem graphql-client already generates `field?` meaning "present in the response", so a predicate that instead meant "was set" would read as a truthiness test.
- **`entry_parameters` rather than `parameters`** — the class method of that name returns metadata, the instance method returns values, and one name for both would be worse than a slightly long one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
